### PR TITLE
Rename tools to fh_* and add version check

### DIFF
--- a/.claude/skills/lab-results/skill.md
+++ b/.claude/skills/lab-results/skill.md
@@ -2,30 +2,30 @@
 name: fh-lab-results
 description: Query Function Health lab results, check for new data, compare visits, and deep-dive on biomarkers. Use when the user asks about labs, bloodwork, biomarkers, or health markers.
 argument-hint: "[summary | check | sync | biomarker <name> | changes | out-of-range | category <name>]"
-allowed-tools: mcp__function-health__function_health_login, mcp__function-health__function_health_status, mcp__function-health__function_health_results, mcp__function-health__function_health_biomarker, mcp__function-health__function_health_summary, mcp__function-health__function_health_categories, mcp__function-health__function_health_changes, mcp__function-health__function_health_sync, mcp__function-health__function_health_check, mcp__function-health__function_health_recommendations, mcp__function-health__function_health_report
+allowed-tools: mcp__function-health__fh_login, mcp__function-health__fh_status, mcp__function-health__fh_results, mcp__function-health__fh_biomarker, mcp__function-health__fh_summary, mcp__function-health__fh_categories, mcp__function-health__fh_changes, mcp__function-health__fh_sync, mcp__function-health__fh_check, mcp__function-health__fh_recommendations, mcp__function-health__fh_report, mcp__function-health__fh_version
 ---
 
 # Lab Results Skill
 
-Query and analyze Function Health lab results. This skill wraps 11 MCP tools for a conversational lab results experience.
+Query and analyze Function Health lab results. This skill wraps 12 MCP tools for a conversational lab results experience.
 
 ## First-Time Setup (Onboarding)
 
-**Always start by calling `function_health_status` to check if the user is authenticated and has data.**
+**Always start by calling `fh_status` to check if the user is authenticated and has data.**
 
 If `authenticated` is false:
 1. Tell the user they need to connect their Function Health account
 2. Ask for their Function Health email and password
-3. Call `function_health_login` with their credentials
-4. On success, automatically run `function_health_sync` to pull their data
+3. Call `fh_login` with their credentials
+4. On success, automatically run `fh_sync` to pull their data
 5. Then proceed with the requested action (or show a summary)
 
 If `authenticated` is true but `hasData` is false:
-1. Run `function_health_sync` to pull data
+1. Run `fh_sync` to pull data
 2. Then proceed with the requested action
 
 If `tokenValid` is false (expired session):
-1. Ask the user to re-authenticate with `function_health_login`
+1. Ask the user to re-authenticate with `fh_login`
 
 ## When to use
 
@@ -56,7 +56,7 @@ Parse from $ARGUMENTS:
 
 ### Default: Health Summary
 
-1. Call `function_health_summary`
+1. Call `fh_summary`
 2. Present conversationally:
    - Total markers tested, how many in/out of range
    - Biological age vs chronological age (if available)
@@ -66,19 +66,19 @@ Parse from $ARGUMENTS:
 
 ### Check for New Results
 
-1. Call `function_health_check`
+1. Call `fh_check`
 2. Report pending/completed requisitions and last sync time
 3. If `newResultsAvailable` is true, ask if user wants to sync
 
 ### Sync
 
-1. Call `function_health_sync`
+1. Call `fh_sync`
 2. Report how many results were pulled and if there are new ones
 3. If new results found, automatically run a changes comparison
 
 ### Biomarker Deep Dive
 
-1. Call `function_health_biomarker` with the name
+1. Call `fh_biomarker` with the name
 2. Present:
    - Current value and whether it's in range
    - Optimal range
@@ -89,7 +89,7 @@ Parse from $ARGUMENTS:
 
 ### Compare Visits
 
-1. Call `function_health_changes`
+1. Call `fh_changes`
 2. Summarize by category:
    - Improved markers (moved into range)
    - Worsened markers (moved out of range)
@@ -99,14 +99,14 @@ Parse from $ARGUMENTS:
 
 ### Out-of-Range Review
 
-1. Call `function_health_results` with `status: "out_of_range"`
+1. Call `fh_results` with `status: "out_of_range"`
 2. Group by severity or category if many results
 3. For each, show name and value
 4. Offer to deep-dive on specific markers
 
 ### Category View
 
-1. Call `function_health_results` with the category name
+1. Call `fh_results` with the category name
 2. Show all markers in that category with values and status
 3. Highlight any out-of-range
 
@@ -123,11 +123,11 @@ Parse from $ARGUMENTS:
 This skill works with `/loop` for automatic checking:
 
 ```
-/loop 6h /lab-results check
+/loop 6h /fh-lab-results check
 ```
 
 When new results are detected:
-1. `function_health_check` returns `newResultsAvailable: true`
-2. Automatically run `function_health_sync`
-3. Run `function_health_changes` to compare with previous visit
+1. `fh_check` returns `newResultsAvailable: true`
+2. Automatically run `fh_sync`
+3. Run `fh_changes` to compare with previous visit
 4. Present the changes summary conversationally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,12 +46,15 @@ node dist/cli.js       # Run CLI
 
 ## MCP Tools
 
-- `function_health_results` - Query results with filters
-- `function_health_biomarker` - Deep dive on one biomarker
-- `function_health_summary` - High-level health overview
-- `function_health_categories` - Category listing
-- `function_health_changes` - Compare visits
-- `function_health_sync` - Pull latest data
-- `function_health_check` - Quick new-results check
-- `function_health_recommendations` - Health recommendations
-- `function_health_report` - Clinician report
+- `fh_login` - Authenticate with Function Health
+- `fh_status` - Check auth/data status
+- `fh_results` - Query results with filters
+- `fh_biomarker` - Deep dive on one biomarker
+- `fh_summary` - High-level health overview
+- `fh_categories` - Category listing
+- `fh_changes` - Compare visits
+- `fh_sync` - Pull latest data
+- `fh_check` - Quick new-results check
+- `fh_recommendations` - Health recommendations
+- `fh_report` - Clinician report
+- `fh_version` - Check for updates

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -74,33 +74,33 @@ function-health-mcp/
 
 ### Core Query Tools
 
-#### `function_health_results`
+#### `fh_results`
 Query lab results with filtering.
 - **Params**: `biomarker?` (name or partial match), `category?` (e.g., "heart", "thyroid"), `status?` ("in_range" | "out_of_range" | "all"), `visit?` ("latest" | "all" | visit number), `date?` (YYYY-MM-DD)
 - **Returns**: Matching results with values, ranges, status, trend vs previous
 
-#### `function_health_biomarker`
+#### `fh_biomarker`
 Deep dive on a specific biomarker.
 - **Params**: `name` (biomarker name, fuzzy match OK)
 - **Returns**: Current value, optimal range, history across all visits, trend direction, clinical context (why it matters, recommendations, foods, supplements)
 
-#### `function_health_summary`
+#### `fh_summary`
 High-level health summary.
 - **Params**: `visit?` ("latest" | visit number)
 - **Returns**: Total markers tested, in-range count, out-of-range count, biological age, BMI, top concerns, top improvements
 
-#### `function_health_categories`
+#### `fh_categories`
 List all biomarker categories with counts.
 - **Returns**: Category name, description, number of biomarkers, number out of range
 
 ### Change Detection Tools
 
-#### `function_health_changes`
+#### `fh_changes`
 Compare results between visits.
 - **Params**: `from_visit?` (defaults to previous), `to_visit?` (defaults to latest)
 - **Returns**: New biomarkers tested, improved (moved into range), worsened (moved out of range), significantly changed (>10% delta), unchanged
 
-#### `function_health_sync`
+#### `fh_sync`
 Pull latest data from Function Health API.
 - **Params**: `force?` (re-export even if recent data exists)
 - **Returns**: Whether new data was found, count of new results, last sync timestamp
@@ -109,18 +109,18 @@ Pull latest data from Function Health API.
   - If new results detected, store the new export with timestamp
   - Return a summary of what changed
 
-#### `function_health_check`
+#### `fh_check`
 Quick check for new results (lightweight — just checks requisition status).
 - **Returns**: Pending requisitions, last completed requisition date, whether new results are available since last sync
 
 ### Reference Tools
 
-#### `function_health_recommendations`
+#### `fh_recommendations`
 Get Function Health's recommendations.
 - **Params**: `category?` (filter by category)
 - **Returns**: Recommendations with associated biomarkers
 
-#### `function_health_report`
+#### `fh_report`
 Get the full clinician report for a visit.
 - **Params**: `visit?` ("latest" | visit number)
 - **Returns**: Clinician notes, interpretations
@@ -176,13 +176,13 @@ Store exported data locally for offline querying and change detection:
 This MCP is designed to be polled via Claude Code's `/loop` command:
 
 ```
-/loop 6h function_health_check
+/loop 6h fh_check
 ```
 
 When new results are detected:
-1. `function_health_check` returns `new_results_available: true`
-2. Claude runs `function_health_sync` to pull and store the new data
-3. Claude runs `function_health_changes` to summarize what changed
+1. `fh_check` returns `new_results_available: true`
+2. Claude runs `fh_sync` to pull and store the new data
+3. Claude runs `fh_changes` to summarize what changed
 4. Claude presents the summary conversationally: "Your new Function Health results are in! 98 of 105 markers in range. 3 improved since last visit (Vitamin D, TSH, LDL). 2 need attention (ferritin dropped, ApoB slightly elevated). Want to dig in?"
 
 ## Development Workflow
@@ -195,20 +195,20 @@ When new results are detected:
 5. Build local data store (`store.ts`) — save/load exports, versioned by date
 
 ### Phase 2: MCP Tools
-6. Implement `function_health_sync` — full export + store
-7. Implement `function_health_results` — query with filters
-8. Implement `function_health_biomarker` — deep dive single marker
-9. Implement `function_health_summary` — high-level overview
-10. Implement `function_health_categories` — category listing
+6. Implement `fh_sync` — full export + store
+7. Implement `fh_results` — query with filters
+8. Implement `fh_biomarker` — deep dive single marker
+9. Implement `fh_summary` — high-level overview
+10. Implement `fh_categories` — category listing
 
 ### Phase 3: Change Detection
 11. Implement `diff.ts` — compare two exports, classify changes
-12. Implement `function_health_changes` — expose diff via MCP
-13. Implement `function_health_check` — lightweight new-results check
+12. Implement `fh_changes` — expose diff via MCP
+13. Implement `fh_check` — lightweight new-results check
 
 ### Phase 4: CLI + Polish
 14. Build CLI with commander (mirror all MCP tools)
-15. Implement `function_health_recommendations` and `function_health_report`
+15. Implement `fh_recommendations` and `fh_report`
 16. Write README with setup instructions
 17. Test end-to-end with real data
 18. Publish to npm

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An MCP server and CLI for [Function Health](https://www.functionhealth.com/) lab
 
 ## Features
 
-- **9 MCP tools** for querying lab results, biomarker deep dives, change detection, and more
+- **12 MCP tools** for querying lab results, biomarker deep dives, change detection, and more
 - **CLI** with matching commands for terminal use
 - **Offline-first** — query tools read from local storage, only sync/check hit the API
 - **Change detection** — compare visits to see what improved, worsened, or changed significantly
@@ -41,7 +41,7 @@ Claude will ask for your Function Health email and password, authenticate, sync 
 
 ### 3. Install the skill (optional)
 
-Copy the skill into your project for a guided `/lab-results` slash command:
+Copy the skill into your project for a guided `/fh-lab-results` slash command:
 
 ```bash
 cp -r node_modules/function-health-mcp/.claude/skills/lab-results your-project/.claude/skills/
@@ -67,17 +67,18 @@ Then use the CLI directly:
 
 | Tool | Description |
 |------|-------------|
-| `function_health_login` | Authenticate with Function Health (email + password) |
-| `function_health_status` | Check auth status, data availability, and sync history |
-| `function_health_results` | Query lab results with filters (biomarker, category, status, visit) |
-| `function_health_biomarker` | Deep dive on a biomarker: value, ranges, history, recommendations |
-| `function_health_summary` | Health overview: totals, biological age, BMI, out-of-range markers |
-| `function_health_categories` | List biomarker categories with counts |
-| `function_health_changes` | Compare two visits: improved, worsened, new, significantly changed |
-| `function_health_sync` | Pull latest data from Function Health API |
-| `function_health_check` | Lightweight check for new results (no full data fetch) |
-| `function_health_recommendations` | Health recommendations, optionally filtered by category |
-| `function_health_report` | Full clinician report for a visit |
+| `fh_login` | Authenticate with Function Health (email + password) |
+| `fh_status` | Check auth status, data availability, and sync history |
+| `fh_results` | Query lab results with filters (biomarker, category, status, visit) |
+| `fh_biomarker` | Deep dive on a biomarker: value, ranges, history, recommendations |
+| `fh_summary` | Health overview: totals, biological age, BMI, out-of-range markers |
+| `fh_categories` | List biomarker categories with counts |
+| `fh_changes` | Compare two visits: improved, worsened, new, significantly changed |
+| `fh_sync` | Pull latest data from Function Health API |
+| `fh_check` | Lightweight check for new results (no full data fetch) |
+| `fh_recommendations` | Health recommendations, optionally filtered by category |
+| `fh_report` | Full clinician report for a visit |
+| `fh_version` | Check installed version and whether an update is available |
 
 ## CLI Commands
 
@@ -99,7 +100,7 @@ function-health export [--markdown]    Full JSON export
 Use Claude Code's `/loop` command to check for new results automatically:
 
 ```
-/loop 6h /lab-results check
+/loop 6h /fh-lab-results check
 ```
 
 This checks every 6 hours. When new results are detected, it syncs and summarizes what changed.
@@ -127,6 +128,10 @@ All data is stored locally at `~/.function-health/`:
 - **Rate-limited**: API requests are serialized with 250ms spacing to respect Function Health's API.
 - **Atomic writes**: Exports use a temp-directory-then-rename pattern to prevent data corruption.
 - **Graceful degradation**: Optional API endpoints (recommendations, notes, biological age) don't block the export if they fail.
+
+## Migrating from v0.2.x
+
+In v0.3.0, all MCP tool names were shortened from `function_health_*` to `fh_*` and the skill was renamed from `lab-results` to `fh-lab-results`. If you have the skill copied into your project, re-copy it to get the updated tool references.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build": "tsc && chmod +x dist/cli.js dist/mcp.js",
     "prepublishOnly": "npm run build",
+    "version": "node -e \"require('fs').writeFileSync('src/version.ts', 'export const VERSION = \\\"' + require('./package.json').version + '\\\";\\n')\" && git add src/version.ts",
     "dev": "tsx src/cli.ts"
   },
   "dependencies": {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -116,7 +116,7 @@ export function isTokenExpired(tokens: AuthTokens): boolean {
 export async function getValidTokens(): Promise<AuthTokens> {
   const creds = await loadCredentials();
   if (!creds?.idToken || !creds?.refreshToken) {
-    throw new Error("Not authenticated. Use the function_health_login tool or run: function-health login");
+    throw new Error("Not authenticated. Use the fh_login tool or run: function-health login");
   }
 
   const tokens: AuthTokens = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { FunctionHealthClient } from "./client.js";
 import { loadLatest, loadExport, saveExport, listExports, getSyncLog } from "./store.js";
 import { diffExports } from "./diff.js";
 import { fuzzyMatch, getResultName, getResultValue, buildCategoryMap, buildOutOfRangeSet, filterResults, resolveSexFilter, resolveSexDetails, findMatchingResults, validateDate, SYNC_COOLDOWN_MS } from "./utils.js";
+import { VERSION } from "./version.js";
 import type { ExportData } from "./types.js";
 
 function validateDateOpt(date: string, label: string): void {
@@ -21,7 +22,7 @@ const program = new Command();
 program
   .name("function-health")
   .description("Function Health lab results CLI")
-  .version("0.1.0");
+  .version(VERSION);
 
 function requireData(data: ExportData | null): asserts data is ExportData {
   if (!data) {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -7,18 +7,19 @@ import { login, loadCredentials, getValidTokens } from "./auth.js";
 import { loadLatest, loadExport, loadExportResults, saveExport, listExports, getSyncLog } from "./store.js";
 import { diffExports } from "./diff.js";
 import { fuzzyMatch, getResultName, getResultValue, buildCategoryMap, buildOutOfRangeSet, filterResults, resolveSexFilter, resolveSexDetails, findMatchingResults, validateDate, SYNC_COOLDOWN_MS } from "./utils.js";
+import { VERSION } from "./version.js";
 import type { ExportData } from "./types.js";
 
 const MAX_HISTORY_CONCURRENCY = 10;
 
-const server = new McpServer({ name: "function-health", version: "0.1.0" });
+const server = new McpServer({ name: "function-health", version: VERSION });
 
 function text(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
 }
 
 function noData() {
-  return text({ error: "No data available. Run function_health_sync first." });
+  return text({ error: "No data available. Run fh_sync first." });
 }
 
 type ToolResult = { content: Array<{ type: "text"; text: string }>; isError?: true };
@@ -37,7 +38,7 @@ function safeTool<T>(fn: (args: T) => Promise<ToolResult>): (args: T) => Promise
 
 // ── Auth Tools ──
 
-server.registerTool("function_health_login", {
+server.registerTool("fh_login", {
   title: "Login",
   description: "Authenticate with Function Health. Required before syncing data. Takes email and password.",
   inputSchema: z.object({
@@ -49,11 +50,11 @@ server.registerTool("function_health_login", {
   return text({
     authenticated: true,
     email: tokens.email,
-    message: "Login successful. You can now run function_health_sync to pull your data.",
+    message: "Login successful. You can now run fh_sync to pull your data.",
   });
 }));
 
-server.registerTool("function_health_status", {
+server.registerTool("fh_status", {
   title: "Auth & Data Status",
   description: "Check authentication status, data availability, and sync history. Use this to determine if the user needs to login or sync.",
   inputSchema: z.object({}),
@@ -87,7 +88,7 @@ server.registerTool("function_health_status", {
 
 // ── Core Query Tools ──
 
-server.registerTool("function_health_results", {
+server.registerTool("fh_results", {
   title: "Lab Results",
   description: "Query lab results with filtering by biomarker name, category, status (in_range/out_of_range), or visit",
   inputSchema: z.object({
@@ -114,7 +115,7 @@ server.registerTool("function_health_results", {
   });
 }));
 
-server.registerTool("function_health_biomarker", {
+server.registerTool("fh_biomarker", {
   title: "Biomarker Deep Dive",
   description: "Get detailed info on a specific biomarker: current value, optimal range, history, clinical context, recommendations",
   inputSchema: z.object({
@@ -172,7 +173,7 @@ server.registerTool("function_health_biomarker", {
   });
 }));
 
-server.registerTool("function_health_summary", {
+server.registerTool("fh_summary", {
   title: "Health Summary",
   description: "High-level health summary: total markers, in/out of range counts, biological age, BMI, top concerns",
   inputSchema: z.object({
@@ -207,7 +208,7 @@ server.registerTool("function_health_summary", {
   });
 }));
 
-server.registerTool("function_health_categories", {
+server.registerTool("fh_categories", {
   title: "Biomarker Categories",
   description: "List all biomarker categories with counts and out-of-range markers",
   inputSchema: z.object({}),
@@ -229,7 +230,7 @@ server.registerTool("function_health_categories", {
 
 // ── Change Detection Tools ──
 
-server.registerTool("function_health_changes", {
+server.registerTool("fh_changes", {
   title: "Compare Visits",
   description: "Compare results between visits to see what improved, worsened, or changed significantly",
   inputSchema: z.object({
@@ -238,7 +239,7 @@ server.registerTool("function_health_changes", {
   }),
 }, safeTool(async ({ from_visit, to_visit }) => {
   const exports = await listExports();
-  if (exports.length < 2) return text({ error: "Need at least 2 exports to compare. Run function_health_sync." });
+  if (exports.length < 2) return text({ error: "Need at least 2 exports to compare. Run fh_sync." });
 
   const fromDate = from_visit ?? exports[exports.length - 2];
   const toDate = to_visit ?? exports[exports.length - 1];
@@ -253,7 +254,7 @@ server.registerTool("function_health_changes", {
   return text(diffExports(fromData, toData));
 }));
 
-server.registerTool("function_health_sync", {
+server.registerTool("fh_sync", {
   title: "Sync Data",
   description: "Pull latest data from Function Health API and store locally. Detects new results. First sync takes 30-60 seconds — warn the user to expect a wait.",
   inputSchema: z.object({
@@ -296,7 +297,7 @@ server.registerTool("function_health_sync", {
   });
 }));
 
-server.registerTool("function_health_check", {
+server.registerTool("fh_check", {
   title: "Check for New Results",
   description: "Quick check for new results (lightweight — checks requisition status)",
   inputSchema: z.object({}),
@@ -331,7 +332,7 @@ server.registerTool("function_health_check", {
 
 // ── Reference Tools ──
 
-server.registerTool("function_health_recommendations", {
+server.registerTool("fh_recommendations", {
   title: "Recommendations",
   description: "Get Function Health's health recommendations, optionally filtered by category",
   inputSchema: z.object({
@@ -352,7 +353,7 @@ server.registerTool("function_health_recommendations", {
   return text(recs);
 }));
 
-server.registerTool("function_health_report", {
+server.registerTool("fh_report", {
   title: "Clinician Report",
   description: "Get the full clinician report for a visit",
   inputSchema: z.object({
@@ -363,6 +364,60 @@ server.registerTool("function_health_report", {
   if (!data) return noData();
 
   return text(data.report);
+}));
+
+// ── Version Tool ──
+
+/** Compare two semver strings numerically (e.g. "0.2.0" vs "0.3.1") */
+function isNewerVersion(current: string, latest: string): boolean {
+  const c = current.split(".").map(Number);
+  const l = latest.split(".").map(Number);
+  for (let i = 0; i < Math.max(c.length, l.length); i++) {
+    const cv = c[i] ?? 0;
+    const lv = l[i] ?? 0;
+    if (lv > cv) return true;
+    if (lv < cv) return false;
+  }
+  return false;
+}
+
+server.registerTool("fh_version", {
+  title: "Version Check",
+  description: "Check the installed version and whether an update is available on npm",
+  inputSchema: z.object({}),
+}, safeTool(async () => {
+  let latest: string | null = null;
+  let updateAvailable = false;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch("https://registry.npmjs.org/function-health-mcp/latest", {
+      signal: controller.signal,
+      headers: { "User-Agent": `function-health-mcp/${VERSION}` },
+    });
+    if (res.ok) {
+      const data = await res.json() as Record<string, unknown>;
+      clearTimeout(timeout);
+      if (typeof data.version === "string") {
+        latest = data.version;
+        updateAvailable = isNewerVersion(VERSION, latest);
+      }
+    } else {
+      clearTimeout(timeout);
+    }
+  } catch {
+    // Network error — degrade gracefully
+  }
+
+  return text({
+    current: VERSION,
+    latest: latest ?? "unknown",
+    updateAvailable,
+    ...(updateAvailable && latest ? {
+      updateInstructions: "If using npx, clear the cache: rm -rf ~/.npm/_npx/**/function-health-mcp. If installed globally: npm install -g function-health-mcp@latest",
+    } : {}),
+  });
 }));
 
 // ── Helpers ──

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "0.2.0";


### PR DESCRIPTION
## Summary
- **Breaking**: Renamed all 11 MCP tools from `function_health_*` to `fh_*` for brevity
- **New**: `fh_version` tool checks npm registry for updates (3s timeout, graceful degradation)
- **New**: `src/version.ts` as single source of truth, synced via `npm version` lifecycle hook
- Updated skill, README (with migration note), CLAUDE.md, and PROMPT.md

Closes #4, closes #2

## Test plan
- [ ] `npm run build` passes
- [ ] MCP tools register with `fh_*` names (restart Claude Code, verify tool list)
- [ ] `fh_version` returns current version and checks npm
- [ ] `fh_status`, `fh_summary`, `fh_results` still work after rename
- [ ] Skill `/fh-lab-results` triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)