### PR TITLE
v0.3.0: Fix 5 issues — per-visit exports, diff fixes, CLI-only login

### DIFF
--- a/.claude/skills/lab-results/skill.md
+++ b/.claude/skills/lab-results/skill.md
@@ -15,17 +15,16 @@ Query and analyze Function Health lab results. This skill wraps 12 MCP tools for
 
 If `authenticated` is false:
 1. Tell the user they need to connect their Function Health account
-2. Ask for their Function Health email and password
-3. Call `fh_login` with their credentials
-4. On success, automatically run `fh_sync` to pull their data
-5. Then proceed with the requested action (or show a summary)
+2. Instruct them to run `npx function-health-mcp login` in their terminal (this keeps their password secure with hidden input)
+3. Once they confirm they've logged in, run `fh_sync` to pull their data
+4. Then proceed with the requested action (or show a summary)
 
 If `authenticated` is true but `hasData` is false:
 1. Run `fh_sync` to pull data
 2. Then proceed with the requested action
 
 If `tokenValid` is false (expired session):
-1. Ask the user to re-authenticate with `fh_login`
+1. Instruct the user to run `npx function-health-mcp login` in their terminal
 
 ## When to use
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.3.0] - 2026-03-09
+
+### Added
+- Per-visit export partitioning — sync now creates separate export directories for each visit date, fixing change detection for users with multiple visits (#10)
+- Disappeared marker detection in diff — biomarkers present in the previous visit but missing from the current one are now reported (#5)
+- Non-numeric value change detection — qualitative changes like "CLEAR" → "ABNORMAL" are now classified as significant changes instead of silently ignored (#5)
+- Requisition count tracking in sync log for accurate new-results detection (#7)
+- Test suite with 42 unit tests covering partitioning, diff, and utility functions
+
+### Changed
+- `fh_login` no longer accepts email/password — directs users to run `npx function-health-mcp login` in the terminal for secure hidden input (#1)
+- `fh_check` now compares completed requisition count against stored requisition count instead of comparing against result count (#7)
+- `fh_sync` sums result counts across all exports for new-results detection
+
+### Removed
+- Dead code in client.ts: `getBiomarkerDetails()`, `getBiomarkerData()`, `makeBiomarkerDetail()`, and `BIOMARKER_DETAIL_STRING_FIELDS` (#8)
+- Password parameters from `fh_login` MCP tool (#1)
+
+### Fixed
+- "Need at least 2 exports to compare" error for users with multiple visits stored in a single export directory (#10)
+- Unit mismatch in `fh_check` — was comparing requisition count (~3) against biomarker result count (~113) (#7)
+
+## [0.2.0] - 2026-03-08
+
+### Added
+- MCP tools renamed from `function_health_*` to `fh_*` for brevity (#4)
+- `fh_version` tool — checks installed version against npm and shows update instructions (#2)
+- `fh_login` and `fh_status` MCP tools
+- `fh_report` tool for clinician reports
+- Sync progress logging with duration warning
+- Lab results skill (`fh-lab-results`) for guided conversational use
+- README, CONTRIBUTING guide, and MCP config examples
+
+### Changed
+- Results extraction uses `/results-report` endpoint (biomarkerResultsRecord) instead of `/results` (which returns PDFs)
+- Skill renamed from `lab-results` to `fh-lab-results`
+
+### Fixed
+- Auth token refresh race condition
+- Atomic export saves with backup/restore on failure
+- Resilient export loading with graceful degradation
+- File permissions enforced via chmod after write
+- `latest.json` changed from full data dump to lightweight pointer
+
+## [0.1.2] - 2026-03-08
+
+### Fixed
+- Multi-category biomarker mapping
+- 5xx response body draining
+- Parallelized requisition check
+
+## [0.1.1] - 2026-03-08
+
+### Fixed
+- Hardening from codex and gemini code reviews
+
+## [0.1.0] - 2026-03-08
+
+### Added
+- Initial release
+- MCP server with stdio transport
+- CLI with commander
+- Firebase authentication with token refresh
+- Local data store with versioned exports
+- Change detection between visits
+- Fuzzy biomarker name matching
+- Rate-limited API client with retry logic

--- a/README.md
+++ b/README.md
@@ -31,13 +31,19 @@ Add to your project's `.mcp.json`:
 
 ### 2. Start using it
 
-Just ask Claude about your lab results. On first use, Claude will walk you through authentication — no CLI needed:
+First, authenticate via the CLI (password input is hidden):
+
+```bash
+npx function-health-mcp login
+```
+
+Then ask Claude about your lab results:
 
 > "Show me my lab results"
 > "Deep dive on my Vitamin D levels"
 > "What changed between my last two visits?"
 
-Claude will ask for your Function Health email and password, authenticate, sync your data, and show your results — all conversationally.
+Claude will sync your data and show your results conversationally.
 
 ### 3. Install the skill (optional)
 
@@ -67,7 +73,7 @@ Then use the CLI directly:
 
 | Tool | Description |
 |------|-------------|
-| `fh_login` | Authenticate with Function Health (email + password) |
+| `fh_login` | Check auth status (directs to CLI login if needed) |
 | `fh_status` | Check auth status, data availability, and sync history |
 | `fh_results` | Query lab results with filters (biomarker, category, status, visit) |
 | `fh_biomarker` | Deep dive on a biomarker: value, ranges, history, recommendations |
@@ -137,6 +143,10 @@ In v0.3.0, all MCP tool names were shortened from `function_health_*` to `fh_*` 
 
 - Node.js 18+ (uses native `fetch`)
 - A [Function Health](https://www.functionhealth.com/) account with lab results
+
+## Acknowledgments
+
+Inspired by [function-health-exporter](https://github.com/bogini/function-health-exporter) by Inigo Beitia Arevalo, which pioneered the reverse-engineered API approach for exporting Function Health lab data.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "build": "tsc && chmod +x dist/cli.js dist/mcp.js",
     "prepublishOnly": "npm run build",
     "version": "node -e \"require('fs').writeFileSync('src/version.ts', 'export const VERSION = \\\"' + require('./package.json').version + '\\\";\\n')\" && git add src/version.ts",
-    "dev": "tsx src/cli.ts"
+    "dev": "tsx src/cli.ts",
+    "test": "tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 import { Command } from "commander";
 import { login, loadCredentials } from "./auth.js";
 import { FunctionHealthClient } from "./client.js";
-import { loadLatest, loadExport, saveExport, listExports, getSyncLog } from "./store.js";
+import { loadLatest, loadExport, saveExport, saveMultiVisitExport, listExports, getSyncLog } from "./store.js";
 import { diffExports } from "./diff.js";
 import { fuzzyMatch, getResultName, getResultValue, buildCategoryMap, buildOutOfRangeSet, filterResults, resolveSexFilter, resolveSexDetails, findMatchingResults, validateDate, SYNC_COOLDOWN_MS } from "./utils.js";
 import { VERSION } from "./version.js";
@@ -92,8 +92,8 @@ program
       const client = await FunctionHealthClient.create();
       console.log("Syncing data from Function Health...");
       const data = await client.exportAll();
-      const exportDate = await saveExport(data);
-      console.log(`Export saved: ${exportDate} (${data.results.length} results)`);
+      const savedDates = await saveMultiVisitExport(data);
+      console.log(`Export saved: ${savedDates.join(", ")} (${data.results.length} results across ${savedDates.length} visit(s))`);
     } catch (err) {
       console.error("Sync failed:", (err as Error).message);
       process.exit(1);
@@ -253,8 +253,8 @@ program
       console.log("Exporting data...");
       const data = await client.exportAll();
 
-      const exportDate = await saveExport(data);
-      console.log(`Data exported and stored (${exportDate})`);
+      const savedDates = await saveMultiVisitExport(data);
+      console.log(`Data exported and stored (${savedDates.join(", ")})`);
 
       if (opts.markdown) {
         console.log("Markdown export not yet implemented.");

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,16 +15,9 @@ import type {
 } from "./types.js";
 import { ApiError } from "./types.js";
 import { getValidTokens, refreshToken, isTokenExpired } from "./auth.js";
-import { BASE_URL, DEFAULT_HEADERS, delay, resolveSexFilter } from "./utils.js";
+import { BASE_URL, DEFAULT_HEADERS, delay } from "./utils.js";
 
 const RATE_LIMIT_MS = 250;
-
-const BIOMARKER_DETAIL_STRING_FIELDS = [
-  "oneLineDescription", "whyItMatters", "recommendations", "causesDescription",
-  "symptomsDescription", "foodsToEatDescription", "foodsToAvoidDescription",
-  "supplementsDescription", "selfCareDescription", "additionalTestsDescription",
-  "followUpDescription", "resourcesCited",
-] as const;
 
 export class FunctionHealthClient {
   private tokens: AuthTokens;
@@ -138,10 +131,6 @@ export class FunctionHealthClient {
     return this.requestArray<Category>("/categories");
   }
 
-  async getBiomarkerData(sexDetailsId: string): Promise<Record<string, unknown> | null> {
-    return this.requestNullable<Record<string, unknown>>(`/biomarker-data/${sexDetailsId}`);
-  }
-
   async getRecommendations(): Promise<Recommendation[]> {
     return this.requestArray<Recommendation>("/recommendations");
   }
@@ -172,31 +161,6 @@ export class FunctionHealthClient {
 
   async getPendingSchedules(): Promise<Schedule[]> {
     return this.requestArray<Schedule>("/pending-schedules");
-  }
-
-  /** Fetch detailed info for all biomarkers (sex-specific).
-   *  Requests are enqueued in parallel — the rate-limited queue serializes them. */
-  async getBiomarkerDetails(biomarkers: Biomarker[], userSex?: string): Promise<BiomarkerDetail[]> {
-    const sexFilter = resolveSexFilter(userSex);
-
-    const promises = biomarkers.map(async (bm) => {
-      const match = bm.sexDetails.find(sd => sd.sex === sexFilter)
-        ?? bm.sexDetails.find(sd => sd.sex === "All");
-
-      if (!match) return makeBiomarkerDetail(bm, sexFilter, null);
-
-      // Gracefully degrade on per-biomarker failures so one transient error
-      // doesn't abort the entire export
-      let data: Record<string, unknown> | null = null;
-      try {
-        data = await this.getBiomarkerData(match.id);
-      } catch {
-        // Fall through with null — makeBiomarkerDetail handles missing data
-      }
-      return makeBiomarkerDetail(bm, sexFilter, data);
-    });
-
-    return Promise.all(promises);
   }
 
   /** Full data export — fetches all data in parallel, extracts results from report */
@@ -299,34 +263,4 @@ function extractResultsFromReport(report: Record<string, unknown> | null): { res
   }
 
   return { results, biomarkerDetails };
-}
-
-function makeBiomarkerDetail(bm: Biomarker, sexFilter: string, data: Record<string, unknown> | null): BiomarkerDetail {
-  const detail: BiomarkerDetail = {
-    id: bm.id,
-    name: bm.name,
-    oneLineDescription: "",
-    whyItMatters: "",
-    recommendations: "",
-    causesDescription: "",
-    symptomsDescription: "",
-    foodsToEatDescription: "",
-    foodsToAvoidDescription: "",
-    supplementsDescription: "",
-    selfCareDescription: "",
-    additionalTestsDescription: "",
-    followUpDescription: "",
-    resourcesCited: "",
-    sexFilter: sexFilter.toLowerCase(),
-    fullData: data,
-  };
-
-  if (data) {
-    detail.name = String(data.name || bm.name);
-    for (const field of BIOMARKER_DETAIL_STRING_FIELDS) {
-      detail[field] = String(data[field] || "");
-    }
-  }
-
-  return detail;
 }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -14,6 +14,7 @@ export function diffExports(from: ExportData, to: ExportData): DiffResult {
   const improved: BiomarkerChange[] = [];
   const worsened: BiomarkerChange[] = [];
   const significantlyChanged: BiomarkerChange[] = [];
+  const disappeared: BiomarkerChange[] = [];
   const unchanged: BiomarkerChange[] = [];
 
   for (const [name, toEntry] of toMap) {
@@ -53,8 +54,29 @@ export function diffExports(from: ExportData, to: ExportData): DiffResult {
     } else if (change.percentChange !== null && Math.abs(change.percentChange) > 10) {
       change.changeType = "changed";
       significantlyChanged.push(change);
+    } else if (change.percentChange === null && fromEntry.value !== toEntry.value) {
+      // Non-numeric value changed (e.g. "CLEAR" → "ABNORMAL")
+      change.changeType = "changed";
+      significantlyChanged.push(change);
     } else {
       unchanged.push(change);
+    }
+  }
+
+  // Detect disappeared markers (in fromMap but not in toMap)
+  for (const [name, fromEntry] of fromMap) {
+    if (!toMap.has(name)) {
+      const category = categoryMap.get(name.toLowerCase()) ?? "Unknown";
+      disappeared.push({
+        biomarkerName: name,
+        category,
+        previousValue: fromEntry.value,
+        currentValue: "",
+        previousInRange: fromEntry.inRange,
+        currentInRange: false,
+        changeType: "disappeared",
+        percentChange: null,
+      });
     }
   }
 
@@ -65,6 +87,7 @@ export function diffExports(from: ExportData, to: ExportData): DiffResult {
     improved,
     worsened,
     significantlyChanged,
+    disappeared,
     unchanged,
     summary: {
       totalCompared: toMap.size,
@@ -72,6 +95,7 @@ export function diffExports(from: ExportData, to: ExportData): DiffResult {
       improvedCount: improved.length,
       worsenedCount: worsened.length,
       significantChangeCount: significantlyChanged.length,
+      disappearedCount: disappeared.length,
       unchangedCount: unchanged.length,
     },
   };

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -3,8 +3,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { FunctionHealthClient } from "./client.js";
-import { login, loadCredentials, getValidTokens } from "./auth.js";
-import { loadLatest, loadExport, loadExportResults, saveExport, listExports, getSyncLog } from "./store.js";
+import { loadCredentials, getValidTokens } from "./auth.js";
+import { loadLatest, loadExport, loadExportResults, saveMultiVisitExport, listExports, getSyncLog, updateRequisitionCount } from "./store.js";
 import { diffExports } from "./diff.js";
 import { fuzzyMatch, getResultName, getResultValue, buildCategoryMap, buildOutOfRangeSet, filterResults, resolveSexFilter, resolveSexDetails, findMatchingResults, validateDate, SYNC_COOLDOWN_MS } from "./utils.js";
 import { VERSION } from "./version.js";
@@ -38,19 +38,33 @@ function safeTool<T>(fn: (args: T) => Promise<ToolResult>): (args: T) => Promise
 
 // ── Auth Tools ──
 
+async function checkAuth(): Promise<{ authenticated: boolean; tokenValid: boolean; email: string | null }> {
+  const creds = await loadCredentials();
+  const authenticated = !!(creds?.idToken && creds?.refreshToken);
+  let tokenValid = false;
+  if (authenticated) {
+    try { await getValidTokens(); tokenValid = true; } catch { /* expired */ }
+  }
+  return { authenticated, tokenValid, email: creds?.email ?? null };
+}
+
 server.registerTool("fh_login", {
   title: "Login",
-  description: "Authenticate with Function Health. Required before syncing data. Takes email and password.",
-  inputSchema: z.object({
-    email: z.string().describe("Function Health account email"),
-    password: z.string().describe("Function Health account password"),
-  }),
-}, safeTool(async ({ email, password }) => {
-  const tokens = await login(email, password);
+  description: "Check authentication status. If not authenticated, instructs the user to run the CLI login command.",
+  inputSchema: z.object({}),
+}, safeTool(async () => {
+  const auth = await checkAuth();
+  if (auth.authenticated && auth.tokenValid) {
+    return text({
+      authenticated: true,
+      email: auth.email,
+      message: "Already authenticated. You can run fh_sync to pull your data.",
+    });
+  }
+
   return text({
-    authenticated: true,
-    email: tokens.email,
-    message: "Login successful. You can now run fh_sync to pull your data.",
+    authenticated: false,
+    message: "Not authenticated. Please run this command in your terminal to log in:\n\n  npx function-health-mcp login\n\nThis keeps your password secure (hidden input). Once logged in, return here and run fh_sync.",
   });
 }));
 
@@ -59,26 +73,12 @@ server.registerTool("fh_status", {
   description: "Check authentication status, data availability, and sync history. Use this to determine if the user needs to login or sync.",
   inputSchema: z.object({}),
 }, safeTool(async () => {
-  const creds = await loadCredentials();
-  const authenticated = !!(creds?.idToken && creds?.refreshToken);
-
-  let tokenValid = false;
-  if (authenticated) {
-    try {
-      await getValidTokens();
-      tokenValid = true;
-    } catch {
-      // Token expired and refresh failed
-    }
-  }
-
+  const auth = await checkAuth();
   const syncLog = await getSyncLog();
   const data = await loadLatest();
 
   return text({
-    authenticated,
-    tokenValid,
-    email: creds?.email ?? null,
+    ...auth,
     lastSync: syncLog.lastSync || null,
     exportCount: syncLog.exports.length,
     hasData: !!data,
@@ -275,21 +275,21 @@ server.registerTool("fh_sync", {
     }
   }
 
-  const previousResultCount = syncLog.exports.length > 0
-    ? syncLog.exports[syncLog.exports.length - 1].resultCount
-    : 0;
+  const previousResultCount = syncLog.exports.reduce((sum, e) => sum + e.resultCount, 0);
 
   server.server.sendLoggingMessage({ level: "info", data: "Syncing — fetching data from Function Health API..." });
   const client = await FunctionHealthClient.create();
   const data = await client.exportAll();
+  const requisitionCount = data.requisitions?.length ?? 0;
   server.server.sendLoggingMessage({ level: "info", data: `Fetched ${data.results.length} results, ${data.biomarkers.length} biomarkers. Saving...` });
-  const exportDate = await saveExport(data);
+  const savedDates = await saveMultiVisitExport(data);
+  await updateRequisitionCount(requisitionCount);
 
   const newResults = data.results.length - previousResultCount;
 
   return text({
     synced: true,
-    exportDate,
+    exportDates: savedDates,
     resultCount: data.results.length,
     newResults: Math.max(0, newResults),
     lastSync: new Date().toISOString(),
@@ -312,14 +312,11 @@ server.registerTool("fh_check", {
 
   const lastSync = syncLog.lastSync;
 
-  // Compare completed requisition count against last export to detect new results
-  // Without a baseline (no prior sync), we can't know if results are "new"
-  const lastExport = syncLog.exports.length > 0
-    ? syncLog.exports[syncLog.exports.length - 1]
-    : null;
-  const newResultsAvailable = lastExport
-    ? completed.length > lastExport.resultCount
-    : false;
+  // Compare completed requisition count against stored count to detect new results
+  const storedRequisitionCount = syncLog.requisitionCount;
+  const newResultsAvailable = storedRequisitionCount !== undefined
+    ? completed.length > storedRequisitionCount
+    : null; // null = unknown, suggest syncing
 
   return text({
     pendingRequisitions: pending.length,

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import type { ExportData, HealthResult, SyncLog } from "./types.js";
-import { deriveExportDate, isValidDateString, writeSecure, isFileNotFound, validateDate, DIR_MODE } from "./utils.js";
+import { deriveExportDate, isValidDateString, writeSecure, isFileNotFound, validateDate, DIR_MODE, partitionByVisitDate } from "./utils.js";
 
 const DATA_DIR = path.join(os.homedir(), ".function-health");
 const EXPORTS_DIR = path.join(DATA_DIR, "exports");
@@ -61,6 +61,27 @@ export async function saveExport(data: ExportData, date?: string): Promise<strin
   }
 
   return exportDate;
+}
+
+/** Save a multi-visit export — partitions by visit date and saves each separately.
+ *  Returns sorted list of saved dates. */
+export async function saveMultiVisitExport(data: ExportData): Promise<string[]> {
+  const partitions = partitionByVisitDate(data);
+  const dates = [...partitions.keys()].sort();
+
+  for (const date of dates) {
+    await saveExport(partitions.get(date)!, date);
+  }
+
+  return dates;
+}
+
+/** Update the requisition count in the sync log (separate from per-export tracking) */
+export async function updateRequisitionCount(count: number): Promise<void> {
+  const log = await getSyncLog();
+  log.requisitionCount = count;
+  await ensureDir(DATA_DIR);
+  await writeSecure(SYNC_LOG_PATH, JSON.stringify(log, null, 2));
 }
 
 /** Load the most recent export (reads pointer file, then loads the export) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,7 @@ export class ApiError extends Error {
 // Sync metadata
 export interface SyncLog {
   lastSync: string;
+  requisitionCount?: number;
   exports: Array<{
     date: string;
     resultCount: number;
@@ -193,7 +194,7 @@ export interface BiomarkerChange {
   currentValue: string;
   previousInRange: boolean | null;
   currentInRange: boolean;
-  changeType: "improved" | "worsened" | "new" | "unchanged" | "changed";
+  changeType: "improved" | "worsened" | "new" | "unchanged" | "changed" | "disappeared";
   percentChange: number | null;
 }
 
@@ -204,6 +205,7 @@ export interface DiffResult {
   improved: BiomarkerChange[];
   worsened: BiomarkerChange[];
   significantlyChanged: BiomarkerChange[];
+  disappeared: BiomarkerChange[];
   unchanged: BiomarkerChange[];
   summary: {
     totalCompared: number;
@@ -211,6 +213,7 @@ export interface DiffResult {
     improvedCount: number;
     worsenedCount: number;
     significantChangeCount: number;
+    disappearedCount: number;
     unchangedCount: number;
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -203,6 +203,39 @@ export function filterResults(
   return filtered;
 }
 
+// ── Export partitioning ──
+
+/** Partition export data by visit date (dateOfService). Each partition gets a copy of shared data. */
+export function partitionByVisitDate(data: ExportData): Map<string, ExportData> {
+  const groups = new Map<string, HealthResult[]>();
+  for (const r of data.results) {
+    const date = (r.dateOfService || "").slice(0, 10);
+    if (!date) continue;
+    const list = groups.get(date);
+    if (list) list.push(r);
+    else groups.set(date, [r]);
+  }
+
+  if (groups.size <= 1) {
+    // Single visit or no results — return as-is keyed by the derived date
+    const date = groups.size === 1 ? [...groups.keys()][0] : deriveExportDate(data, new Date().toISOString().slice(0, 10));
+    const result = new Map<string, ExportData>();
+    result.set(date, data);
+    return result;
+  }
+
+  const partitions = new Map<string, ExportData>();
+  for (const [date, results] of groups) {
+    const resultNames = new Set(results.map(r => (getResultName(r) || "").toLowerCase()));
+    partitions.set(date, {
+      ...data,
+      results,
+      biomarkerDetails: data.biomarkerDetails.filter(d => resultNames.has(d.name.toLowerCase())),
+    });
+  }
+  return partitions;
+}
+
 // ── Misc ──
 
 /** Delay for rate limiting */

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -1,0 +1,193 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { diffExports } from "../src/diff.js";
+import { makeResult, makeExport } from "./helpers.js";
+
+function makeBiomarker(name: string) {
+  return { id: `bm-${name}`, name, questBiomarkerCode: "", categories: [], sexDetails: [], status: null };
+}
+
+describe("diffExports", () => {
+  it("detects new markers (in 'to' but not 'from')", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "Vitamin D", dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("Vitamin D")],
+    });
+    const to = makeExport({
+      results: [
+        makeResult({ biomarkerName: "Vitamin D", dateOfService: "2026-01-29" }),
+        makeResult({ biomarkerName: "Iron", dateOfService: "2026-01-29" }),
+      ],
+      biomarkers: [makeBiomarker("Vitamin D"), makeBiomarker("Iron")],
+    });
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.summary.newCount, 1);
+    assert.equal(diff.newBiomarkers[0].biomarkerName, "Iron");
+  });
+
+  it("detects disappeared markers (in 'from' but not 'to')", () => {
+    const from = makeExport({
+      results: [
+        makeResult({ biomarkerName: "Vitamin D", dateOfService: "2026-01-20" }),
+        makeResult({ biomarkerName: "Iron", dateOfService: "2026-01-20" }),
+      ],
+      biomarkers: [makeBiomarker("Vitamin D"), makeBiomarker("Iron")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "Vitamin D", dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("Vitamin D")],
+    });
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.summary.disappearedCount, 1);
+    assert.equal(diff.disappeared[0].biomarkerName, "Iron");
+    assert.equal(diff.disappeared[0].changeType, "disappeared");
+    assert.equal(diff.disappeared[0].currentValue, "");
+  });
+
+  it("detects improved markers (out of range → in range)", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "Vitamin D", displayResult: "20", inRange: false, dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("Vitamin D")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "Vitamin D", displayResult: "45", inRange: true, dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("Vitamin D")],
+    });
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.summary.improvedCount, 1);
+    assert.equal(diff.improved[0].changeType, "improved");
+  });
+
+  it("detects worsened markers (in range → out of range)", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "Glucose", displayResult: "90", inRange: true, dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("Glucose")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "Glucose", displayResult: "130", inRange: false, dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("Glucose")],
+    });
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.summary.worsenedCount, 1);
+    assert.equal(diff.worsened[0].changeType, "worsened");
+  });
+
+  it("detects significant numeric change (>10%) within same range status", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "LDL", displayResult: "100", inRange: true, dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("LDL")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "LDL", displayResult: "120", inRange: true, dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("LDL")],
+    });
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.summary.significantChangeCount, 1);
+    assert.equal(diff.significantlyChanged[0].changeType, "changed");
+    assert.equal(diff.significantlyChanged[0].percentChange, 20);
+  });
+
+  it("classifies small numeric change as unchanged", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "LDL", displayResult: "100", inRange: true, dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("LDL")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "LDL", displayResult: "105", inRange: true, dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("LDL")],
+    });
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.summary.unchangedCount, 1);
+  });
+
+  it("detects non-numeric value change as significant", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "Urinalysis", displayResult: "CLEAR", calculatedResult: "CLEAR", inRange: true, dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("Urinalysis")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "Urinalysis", displayResult: "ABNORMAL", calculatedResult: "ABNORMAL", inRange: true, dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("Urinalysis")],
+    });
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.summary.significantChangeCount, 1);
+    assert.equal(diff.significantlyChanged[0].changeType, "changed");
+    assert.equal(diff.significantlyChanged[0].percentChange, null);
+  });
+
+  it("classifies identical non-numeric values as unchanged", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "Urinalysis", displayResult: "CLEAR", calculatedResult: "CLEAR", inRange: true, dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("Urinalysis")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "Urinalysis", displayResult: "CLEAR", calculatedResult: "CLEAR", inRange: true, dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("Urinalysis")],
+    });
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.summary.unchangedCount, 1);
+  });
+
+  it("calculates correct percent change", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "TSH", displayResult: "2.0", inRange: true, dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("TSH")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "TSH", displayResult: "3.0", inRange: true, dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("TSH")],
+    });
+
+    const diff = diffExports(from, to);
+    // 50% increase → classified as significant change
+    assert.equal(diff.significantlyChanged[0].percentChange, 50);
+  });
+
+  it("sets correct fromDate and toDate from results", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "A", dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("A")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "A", dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("A")],
+    });
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.fromDate, "2026-01-20");
+    assert.equal(diff.toDate, "2026-01-29");
+  });
+
+  it("handles empty exports without crashing", () => {
+    const from = makeExport();
+    const to = makeExport();
+
+    const diff = diffExports(from, to);
+    assert.equal(diff.summary.totalCompared, 0);
+    assert.equal(diff.summary.disappearedCount, 0);
+  });
+
+  it("handles values like '<0.2' as non-numeric", () => {
+    const from = makeExport({
+      results: [makeResult({ biomarkerName: "hsCRP", displayResult: "<0.2", calculatedResult: "<0.2", inRange: true, dateOfService: "2026-01-20" })],
+      biomarkers: [makeBiomarker("hsCRP")],
+    });
+    const to = makeExport({
+      results: [makeResult({ biomarkerName: "hsCRP", displayResult: "1.5", calculatedResult: "1.5", inRange: true, dateOfService: "2026-01-29" })],
+      biomarkers: [makeBiomarker("hsCRP")],
+    });
+
+    const diff = diffExports(from, to);
+    // "<0.2" parseFloat gives NaN on some engines, or 0.2 on others
+    // Either way, a change should be detected (not silently unchanged)
+    assert.equal(diff.summary.unchangedCount, 0);
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,56 @@
+import type { ExportData, HealthResult, BiomarkerDetail } from "../src/types.js";
+
+/** Create a minimal HealthResult for testing */
+export function makeResult(overrides: Partial<HealthResult> = {}): HealthResult {
+  return {
+    id: "r1",
+    biomarkerName: "Vitamin D",
+    dateOfService: "2026-01-20",
+    calculatedResult: "30",
+    displayResult: "30",
+    inRange: true,
+    requisitionId: "req1",
+    ...overrides,
+  };
+}
+
+/** Create a minimal BiomarkerDetail for testing */
+export function makeDetail(name: string): BiomarkerDetail {
+  return {
+    id: `detail-${name}`,
+    name,
+    oneLineDescription: "",
+    whyItMatters: "",
+    recommendations: "",
+    causesDescription: "",
+    symptomsDescription: "",
+    foodsToEatDescription: "",
+    foodsToAvoidDescription: "",
+    supplementsDescription: "",
+    selfCareDescription: "",
+    additionalTestsDescription: "",
+    followUpDescription: "",
+    resourcesCited: "",
+    sexFilter: "",
+    fullData: null,
+  };
+}
+
+/** Create a minimal ExportData for testing */
+export function makeExport(overrides: Partial<ExportData> = {}): ExportData {
+  return {
+    profile: null,
+    results: [],
+    biomarkers: [],
+    categories: [],
+    biomarkerDetails: [],
+    recommendations: [],
+    report: null,
+    biologicalAge: null,
+    bmi: null,
+    notes: [],
+    requisitions: [],
+    pendingSchedules: [],
+    ...overrides,
+  };
+}

--- a/test/partition.test.ts
+++ b/test/partition.test.ts
@@ -1,0 +1,130 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { partitionByVisitDate } from "../src/utils.js";
+import { makeResult, makeDetail, makeExport } from "./helpers.js";
+
+describe("partitionByVisitDate", () => {
+  it("returns single partition for single visit date", () => {
+    const data = makeExport({
+      results: [
+        makeResult({ biomarkerName: "Vitamin D", dateOfService: "2026-01-20" }),
+        makeResult({ biomarkerName: "Iron", dateOfService: "2026-01-20" }),
+      ],
+      biomarkerDetails: [makeDetail("Vitamin D"), makeDetail("Iron")],
+    });
+
+    const partitions = partitionByVisitDate(data);
+    assert.equal(partitions.size, 1);
+    assert.ok(partitions.has("2026-01-20"));
+
+    const partition = partitions.get("2026-01-20")!;
+    assert.equal(partition.results.length, 2);
+    // Single partition returns original data unchanged
+    assert.equal(partition, data);
+  });
+
+  it("partitions results by dateOfService for multiple visits", () => {
+    const data = makeExport({
+      results: [
+        makeResult({ biomarkerName: "Vitamin D", dateOfService: "2026-01-20" }),
+        makeResult({ biomarkerName: "Iron", dateOfService: "2026-01-20" }),
+        makeResult({ biomarkerName: "B12", dateOfService: "2026-01-29" }),
+        makeResult({ biomarkerName: "Folate", dateOfService: "2026-01-29" }),
+        makeResult({ biomarkerName: "Zinc", dateOfService: "2026-01-29" }),
+      ],
+      biomarkerDetails: [
+        makeDetail("Vitamin D"), makeDetail("Iron"),
+        makeDetail("B12"), makeDetail("Folate"), makeDetail("Zinc"),
+      ],
+    });
+
+    const partitions = partitionByVisitDate(data);
+    assert.equal(partitions.size, 2);
+
+    const jan20 = partitions.get("2026-01-20")!;
+    assert.equal(jan20.results.length, 2);
+    assert.deepEqual(jan20.results.map(r => r.biomarkerName).sort(), ["Iron", "Vitamin D"]);
+    assert.equal(jan20.biomarkerDetails.length, 2);
+
+    const jan29 = partitions.get("2026-01-29")!;
+    assert.equal(jan29.results.length, 3);
+    assert.deepEqual(jan29.results.map(r => r.biomarkerName).sort(), ["B12", "Folate", "Zinc"]);
+    assert.equal(jan29.biomarkerDetails.length, 3);
+  });
+
+  it("filters biomarkerDetails to match each partition's results", () => {
+    const data = makeExport({
+      results: [
+        makeResult({ biomarkerName: "Vitamin D", dateOfService: "2026-01-20" }),
+        makeResult({ biomarkerName: "Iron", dateOfService: "2026-01-29" }),
+      ],
+      biomarkerDetails: [makeDetail("Vitamin D"), makeDetail("Iron"), makeDetail("Unused")],
+    });
+
+    const partitions = partitionByVisitDate(data);
+    const jan20 = partitions.get("2026-01-20")!;
+    const jan29 = partitions.get("2026-01-29")!;
+
+    assert.deepEqual(jan20.biomarkerDetails.map(d => d.name), ["Vitamin D"]);
+    assert.deepEqual(jan29.biomarkerDetails.map(d => d.name), ["Iron"]);
+  });
+
+  it("shares non-result data across all partitions", () => {
+    const profile = { id: "p1", patientIdentifier: "P001", fname: "Test", lname: "User", preferredName: "", biologicalSex: "Male", dob: "1990-01-01", pronouns: "", canScheduleInBetaStates: false, patientContactInfo: { email: "", phoneNumber: "", streetAddress: "", city: "", state: "", zip: "" }, dateJoined: "", intake_status: false, patientMembership: "" };
+    const data = makeExport({
+      profile,
+      results: [
+        makeResult({ biomarkerName: "A", dateOfService: "2026-01-20" }),
+        makeResult({ biomarkerName: "B", dateOfService: "2026-01-29" }),
+      ],
+      biomarkerDetails: [makeDetail("A"), makeDetail("B")],
+      categories: [{ id: "c1", categoryName: "Heart", description: "", biomarkers: [] }],
+    });
+
+    const partitions = partitionByVisitDate(data);
+    for (const [, partition] of partitions) {
+      assert.equal(partition.profile, profile);
+      assert.equal(partition.categories, data.categories);
+      assert.equal(partition.recommendations, data.recommendations);
+    }
+  });
+
+  it("handles results with no dateOfService gracefully", () => {
+    const data = makeExport({
+      results: [
+        makeResult({ biomarkerName: "A", dateOfService: "" }),
+        makeResult({ biomarkerName: "B", dateOfService: "2026-01-20" }),
+      ],
+      biomarkerDetails: [makeDetail("A"), makeDetail("B")],
+    });
+
+    const partitions = partitionByVisitDate(data);
+    // Result with empty dateOfService is skipped from grouping
+    // Only one date group → single partition returns original data
+    assert.equal(partitions.size, 1);
+    assert.ok(partitions.has("2026-01-20"));
+  });
+
+  it("returns fallback date when no results exist", () => {
+    const data = makeExport({ results: [] });
+    const partitions = partitionByVisitDate(data);
+    assert.equal(partitions.size, 1);
+    // Should use deriveExportDate fallback (today's date)
+    const [date] = [...partitions.keys()];
+    assert.match(date, /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("truncates dateOfService to YYYY-MM-DD", () => {
+    const data = makeExport({
+      results: [
+        makeResult({ biomarkerName: "A", dateOfService: "2026-01-20T10:30:00Z" }),
+        makeResult({ biomarkerName: "B", dateOfService: "2026-01-20T14:00:00Z" }),
+      ],
+      biomarkerDetails: [makeDetail("A"), makeDetail("B")],
+    });
+
+    const partitions = partitionByVisitDate(data);
+    assert.equal(partitions.size, 1);
+    assert.ok(partitions.has("2026-01-20"));
+  });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,154 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { deriveExportDate, validateDate, isValidDateString, fuzzyMatch, getResultName, getResultValue, buildOutOfRangeSet, filterResults } from "../src/utils.js";
+import { makeResult } from "./helpers.js";
+
+describe("deriveExportDate", () => {
+  it("returns latest dateOfService from results", () => {
+    const data = {
+      results: [
+        makeResult({ dateOfService: "2026-01-20" }),
+        makeResult({ dateOfService: "2026-01-29" }),
+        makeResult({ dateOfService: "2026-01-15" }),
+      ],
+    };
+    assert.equal(deriveExportDate(data), "2026-01-29");
+  });
+
+  it("returns fallback when no results", () => {
+    assert.equal(deriveExportDate({ results: [] }), "unknown");
+    assert.equal(deriveExportDate({ results: [] }, "2026-03-01"), "2026-03-01");
+  });
+
+  it("truncates dateOfService with timestamps", () => {
+    const data = { results: [makeResult({ dateOfService: "2026-01-20T10:30:00Z" })] };
+    assert.equal(deriveExportDate(data), "2026-01-20");
+  });
+});
+
+describe("validateDate", () => {
+  it("accepts valid YYYY-MM-DD dates", () => {
+    assert.equal(validateDate("2026-01-20"), "2026-01-20");
+    assert.equal(validateDate("2000-12-31"), "2000-12-31");
+  });
+
+  it("rejects invalid formats", () => {
+    assert.throws(() => validateDate("01-20-2026"));
+    assert.throws(() => validateDate("2026/01/20"));
+    assert.throws(() => validateDate("not-a-date"));
+    assert.throws(() => validateDate(""));
+  });
+
+  it("rejects overflow dates", () => {
+    assert.throws(() => validateDate("2026-13-01")); // month 13
+    assert.throws(() => validateDate("2026-02-30")); // Feb 30
+  });
+});
+
+describe("isValidDateString", () => {
+  it("validates correct dates", () => {
+    assert.equal(isValidDateString("2026-01-20"), true);
+    assert.equal(isValidDateString("2026-02-28"), true);
+  });
+
+  it("rejects invalid dates", () => {
+    assert.equal(isValidDateString("2026-13-01"), false);
+    assert.equal(isValidDateString("abc"), false);
+    assert.equal(isValidDateString("2026-1-1"), false);
+  });
+});
+
+describe("fuzzyMatch", () => {
+  it("matches case-insensitively", () => {
+    assert.equal(fuzzyMatch("vitamin d", "Vitamin D"), true);
+    assert.equal(fuzzyMatch("VITAMIN D", "vitamin d"), true);
+  });
+
+  it("matches substrings", () => {
+    assert.equal(fuzzyMatch("vitamin", "Vitamin D, 25-Hydroxy"), true);
+    assert.equal(fuzzyMatch("tsh", "TSH (Thyroid Stimulating Hormone)"), true);
+  });
+
+  it("rejects non-matches", () => {
+    assert.equal(fuzzyMatch("iron", "Vitamin D"), false);
+  });
+
+  it("handles whitespace in query", () => {
+    assert.equal(fuzzyMatch("  vitamin d  ", "Vitamin D"), true);
+  });
+});
+
+describe("getResultName", () => {
+  it("returns biomarkerName when present", () => {
+    assert.equal(getResultName(makeResult({ biomarkerName: "Vitamin D" })), "Vitamin D");
+  });
+
+  it("falls back to name field", () => {
+    const r = { name: "Iron", id: "1", dateOfService: "", calculatedResult: "", displayResult: "", inRange: true, requisitionId: "" };
+    assert.equal(getResultName(r), "Iron");
+  });
+
+  it("uses idToName map for biomarkerId fallback", () => {
+    const idToName = new Map([["bm1", "Zinc"]]);
+    const r = { biomarkerId: "bm1", id: "1", dateOfService: "", calculatedResult: "", displayResult: "", inRange: true, requisitionId: "" };
+    assert.equal(getResultName(r, idToName), "Zinc");
+  });
+
+  it("returns null when no name can be resolved", () => {
+    const r = { id: "1", dateOfService: "", calculatedResult: "", displayResult: "", inRange: true, requisitionId: "" };
+    assert.equal(getResultName(r), null);
+  });
+});
+
+describe("getResultValue", () => {
+  it("prefers displayResult", () => {
+    assert.equal(getResultValue(makeResult({ displayResult: "30 ng/mL", calculatedResult: "30" })), "30 ng/mL");
+  });
+
+  it("falls back to calculatedResult", () => {
+    assert.equal(getResultValue(makeResult({ displayResult: "", calculatedResult: "30" })), "30");
+  });
+});
+
+describe("buildOutOfRangeSet", () => {
+  it("collects lowercase names of out-of-range results", () => {
+    const results = [
+      makeResult({ biomarkerName: "Vitamin D", inRange: false }),
+      makeResult({ biomarkerName: "Iron", inRange: true }),
+      makeResult({ biomarkerName: "B12", inRange: false }),
+    ];
+    const set = buildOutOfRangeSet(results);
+    assert.equal(set.has("vitamin d"), true);
+    assert.equal(set.has("b12"), true);
+    assert.equal(set.has("iron"), false);
+  });
+});
+
+describe("filterResults", () => {
+  const results = [
+    makeResult({ biomarkerName: "Vitamin D", inRange: true }),
+    makeResult({ biomarkerName: "Iron", inRange: false }),
+    makeResult({ biomarkerName: "Vitamin B12", inRange: true }),
+  ];
+
+  it("filters by biomarker name (fuzzy)", () => {
+    const filtered = filterResults(results, { biomarker: "vitamin" });
+    assert.equal(filtered.length, 2);
+  });
+
+  it("filters by status in_range", () => {
+    const filtered = filterResults(results, { status: "in_range" });
+    assert.equal(filtered.length, 2);
+  });
+
+  it("filters by status out_of_range", () => {
+    const filtered = filterResults(results, { status: "out_of_range" });
+    assert.equal(filtered.length, 1);
+    assert.equal(filtered[0].biomarkerName, "Iron");
+  });
+
+  it("returns all when no filters", () => {
+    const filtered = filterResults(results, {});
+    assert.equal(filtered.length, 3);
+  });
+});


### PR DESCRIPTION
## Summary

- **#10** Per-visit export partitioning — sync creates separate export directories per visit date, fixing "Need at least 2 exports" for users with multiple visits
- **#5** Diff now detects disappeared markers and non-numeric value changes (e.g. "CLEAR" → "ABNORMAL")
- **#7** Fix unit mismatch in `fh_check` — compares requisition counts instead of requisition vs result count
- **#8** Remove dead code from client.ts (`getBiomarkerDetails`, `getBiomarkerData`, `makeBiomarkerDetail`)
- **#1** `fh_login` no longer accepts password — directs users to `npx function-health-mcp login` for secure hidden input
- Add test suite (42 unit tests) and CHANGELOG.md

## Test plan

- [ ] `npm test` — 42 unit tests pass
- [ ] `npm run build` — clean build
- [ ] Manual: sync creates multiple export directories (one per visit date)
- [ ] Manual: `fh_changes` works with partitioned exports
- [ ] Manual: `fh_check` correctly compares requisition counts
- [ ] Manual: `fh_login` returns CLI login instructions (no password params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)