### PR TITLE
feat: change detection notifications (#13)

### DIFF
--- a/.claude/skills/lab-results/skill.md
+++ b/.claude/skills/lab-results/skill.md
@@ -2,12 +2,12 @@
 name: fh-lab-results
 description: Query Function Health lab results, check for new data, compare visits, and deep-dive on biomarkers. Use when the user asks about labs, bloodwork, biomarkers, or health markers.
 argument-hint: "[summary | check | sync | biomarker <name> | changes | out-of-range | category <name>]"
-allowed-tools: mcp__function-health__fh_login, mcp__function-health__fh_status, mcp__function-health__fh_results, mcp__function-health__fh_biomarker, mcp__function-health__fh_summary, mcp__function-health__fh_categories, mcp__function-health__fh_changes, mcp__function-health__fh_sync, mcp__function-health__fh_check, mcp__function-health__fh_recommendations, mcp__function-health__fh_report, mcp__function-health__fh_version
+allowed-tools: mcp__function-health__fh_login, mcp__function-health__fh_status, mcp__function-health__fh_results, mcp__function-health__fh_biomarker, mcp__function-health__fh_summary, mcp__function-health__fh_categories, mcp__function-health__fh_changes, mcp__function-health__fh_sync, mcp__function-health__fh_check, mcp__function-health__fh_recommendations, mcp__function-health__fh_report, mcp__function-health__fh_version, mcp__function-health__fh_notifications
 ---
 
 # Lab Results Skill
 
-Query and analyze Function Health lab results. This skill wraps 12 MCP tools for a conversational lab results experience.
+Query and analyze Function Health lab results. This skill wraps 13 MCP tools for a conversational lab results experience.
 
 ## First-Time Setup (Onboarding)
 
@@ -86,6 +86,24 @@ Parse from $ARGUMENTS:
    - Recommendations (foods, supplements, lifestyle)
 3. Keep it conversational — lead with the number, then context
 
+### Daily Briefing
+
+For daily review / morning briefing, include a Function Health section:
+
+1. Call `fh_notifications` (without acknowledge) to check for pending changes
+2. If no notifications → report "No new lab data" and move on
+3. If there are notifications, present them:
+   - Lead with what's significant: worsened markers, biological age changes
+   - Then improvements and new results
+   - For new results, automatically call `fh_changes` to compare against previous rounds of the same tests — show how values moved
+   - For any newly out-of-range marker, call `fh_biomarker` to get context and recommendations
+4. After presenting everything, call `fh_notifications` with `acknowledge: true` to clear
+
+This ensures the user gets a complete picture without needing to ask follow-up questions.
+
+**Example output:**
+> **Function Health:** New lab results came in yesterday. 3 new results — Vitamin D improved to 42 (was 28, now in range), A1C steady at 5.4. LDL moved out of range at 142 (was 128). I'd recommend focusing on the LDL — here are the dietary recommendations...
+
 ### Compare Test Rounds
 
 1. Call `fh_changes`
@@ -120,14 +138,12 @@ Parse from $ARGUMENTS:
 
 ## Periodic Monitoring
 
-This skill works with `/loop` for automatic checking:
+Background syncs keep data fresh:
 
 ```
-/loop 6h /fh-lab-results check
+/loop 6h /fh-lab-results sync
 ```
 
-When new results are detected:
-1. `fh_check` returns `newResultsAvailable: true`
-2. Automatically run `fh_sync`
-3. Run `fh_changes` to compare with previous visit
-4. Present the changes summary conversationally
+Syncs automatically write change notification files when anything changes. The daily briefing workflow (above) picks these up — no manual checking needed.
+
+Change notifications persist across conversations, so missed days don't lose data. New lab results from Function Health typically arrive in batches over several weeks as different panels complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ MCP server + CLI for querying Function Health lab results, detecting changes bet
 
 ```
 src/
-  mcp.ts       - MCP server entry point (stdio transport, 12 tools)
-  cli.ts       - CLI entry point (commander, 10 commands)
+  mcp.ts       - MCP server entry point (stdio transport, 13 tools)
+  cli.ts       - CLI entry point (commander, 11 commands)
   client.ts    - Function Health API client (rate-limited, token-managed)
   auth.ts      - Firebase auth (login, token refresh, credential storage)
   types.ts     - TypeScript interfaces
@@ -16,11 +16,12 @@ src/
   utils.ts     - groupByRound, fuzzy match, date helpers, file helpers
   version.ts   - Version constant
 test/
-  round.test.ts      - groupByRound tests
-  diff.test.ts       - diffExports tests
-  migration.test.ts  - Migration and extraction helpers
-  utils.test.ts      - Utility function tests
-  helpers.ts         - Test factories (makeResult, makeExport, etc.)
+  round.test.ts         - groupByRound tests
+  diff.test.ts          - diffExports tests
+  notifications.test.ts - diffMeta, buildChangeSummary tests
+  migration.test.ts     - Migration and extraction helpers
+  utils.test.ts         - Utility function tests
+  helpers.ts            - Test factories (makeResult, makeExport, etc.)
 docs/
   api-reference.md   - Reverse-engineered Function Health API documentation
 ```
@@ -30,7 +31,7 @@ docs/
 ```bash
 npm run build          # TypeScript → dist/
 npm run dev            # Run CLI via tsx
-npm test               # Run 60 unit tests via node:test + tsx
+npm test               # Run 75 unit tests via node:test + tsx
 node dist/mcp.js       # Run MCP server
 node dist/cli.js       # Run CLI
 ```
@@ -52,6 +53,8 @@ node dist/cli.js       # Run CLI
   credentials.json     - Auth tokens (0o600)
   latest.json          - Pointer to most recent export
   sync-log.json        - Sync history and requisition tracking
+  changes/
+    {timestamp}.json   - Change notifications (accumulate until acknowledged)
   exports/
     YYYY-MM-DD/        - One directory per test round (keyed by earliest visit date)
       results.json     - All results across all visits in this round
@@ -78,8 +81,9 @@ node dist/cli.js       # Run CLI
 - `fh_summary` - Health overview: totals, biological age, BMI, out-of-range
 - `fh_categories` - Category listing with out-of-range counts
 - `fh_changes` - Compare two test rounds: improved, worsened, new, changed
-- `fh_sync` - Pull latest data (auto-migrates old exports to round model)
+- `fh_sync` - Pull latest data, detect changes, write notifications
 - `fh_check` - Lightweight new-results check (requisition count only)
+- `fh_notifications` - Read/clear change notifications from syncs
 - `fh_recommendations` - Health recommendations, optionally by category
 - `fh_report` - Full clinician report
 - `fh_version` - Check for updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "function-health-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Function Health MCP server and CLI — query lab results, detect changes, track biomarkers",
   "type": "module",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,8 @@
 import { Command } from "commander";
 import { login, loadCredentials, getValidTokens, clearCredentials } from "./auth.js";
 import { FunctionHealthClient } from "./client.js";
-import { loadLatest, loadExport, saveRoundExport, listExports, getSyncLog, loadRoundMeta, migrateToRounds } from "./store.js";
-import { diffExports } from "./diff.js";
+import { loadLatest, loadExport, saveRoundExport, listExports, getSyncLog, loadRoundMeta, migrateToRounds, loadAllExportsAggregated, loadChangeNotifications, clearChangeNotifications } from "./store.js";
+import { diffExports, detectAndSaveChanges } from "./diff.js";
 import { fuzzyMatch, getResultName, getResultValue, buildCategoryMap, buildOutOfRangeSet, filterResults, resolveSexFilter, resolveSexDetails, findMatchingResults, validateDate, SYNC_COOLDOWN_MS } from "./utils.js";
 import { VERSION } from "./version.js";
 import type { ExportData } from "./types.js";
@@ -128,11 +128,26 @@ program
       // Migrate old per-visit exports to round-based (idempotent)
       await migrateToRounds();
 
+      // Before saving: aggregate all existing rounds for change detection
+      const { data: previousData, roundCount: previousRoundCount } = await loadAllExportsAggregated();
+
       const client = await FunctionHealthClient.create();
       console.log("Syncing data from Function Health...");
       const data = await client.exportAll();
       const savedDates = await saveRoundExport(data);
       console.log(`Export saved: ${savedDates.join(", ")} (${data.results.length} results across ${savedDates.length} test round(s))`);
+
+      // Change detection
+      const summary = await detectAndSaveChanges(previousData, data, savedDates, previousRoundCount);
+
+      if (summary.length > 0) {
+        console.log("\nChanges detected:");
+        for (const line of summary) {
+          console.log(`  • ${line}`);
+        }
+      } else if (previousData) {
+        console.log("No changes detected.");
+      }
     } catch (err) {
       console.error("Sync failed:", (err as Error).message);
       process.exit(1);
@@ -157,6 +172,32 @@ program
     } catch (err) {
       console.error("Check failed:", (err as Error).message);
       process.exit(1);
+    }
+  });
+
+program
+  .command("notifications")
+  .description("Show pending change notifications from syncs")
+  .option("--clear", "Clear notifications after displaying")
+  .action(async (opts) => {
+    const { notifications, files } = await loadChangeNotifications();
+    if (notifications.length === 0) {
+      console.log("No pending notifications.");
+      return;
+    }
+
+    console.log(`${notifications.length} notification(s):\n`);
+    for (const n of notifications) {
+      console.log(`[${n.timestamp}]`);
+      for (const line of n.summary) {
+        console.log(`  • ${line}`);
+      }
+      console.log();
+    }
+
+    if (opts.clear) {
+      const count = await clearChangeNotifications(files);
+      console.log(`Cleared ${count} notification(s).`);
     }
   });
 

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,5 +1,7 @@
-import type { ExportData, BiomarkerChange, DiffResult } from "./types.js";
+import { isDeepStrictEqual } from "node:util";
+import type { ExportData, BiomarkerChange, DiffResult, MetaChanges, ChangeNotification } from "./types.js";
 import { getResultName, getResultValue, deriveExportDate, buildCategoryMap, byDateDesc } from "./utils.js";
+import { saveChangeNotification } from "./store.js";
 
 /** Compare two exports and classify changes.
  *  Optional labels override the derived dates (useful when the storage key
@@ -106,6 +108,213 @@ export function diffExports(from: ExportData, to: ExportData, fromLabel?: string
 interface ResultEntry {
   value: string;
   inRange: boolean;
+}
+
+/** Compare non-result metadata between two exports. Only populates fields that changed. */
+export function diffMeta(from: ExportData | null, to: ExportData): MetaChanges {
+  const changes: MetaChanges = {};
+
+  // Biological age
+  const prevAge = from?.biologicalAge?.biologicalAge ?? null;
+  const currAge = to.biologicalAge?.biologicalAge ?? null;
+  if (prevAge !== currAge) {
+    changes.biologicalAge = { previous: prevAge, current: currAge };
+  }
+
+  // BMI
+  const prevBmi = from?.bmi?.bmi ?? null;
+  const currBmi = to.bmi?.bmi ?? null;
+  if (prevBmi !== currBmi) {
+    changes.bmi = { previous: prevBmi, current: currBmi };
+  }
+
+  // Recommendations (compare count and content, order-insensitive)
+  const prevRecs = from?.recommendations ?? [];
+  const currRecs = to.recommendations ?? [];
+  if (prevRecs.length !== currRecs.length) {
+    changes.recommendationCountDelta = currRecs.length - prevRecs.length;
+  } else if (!isDeepStrictEqual(sortById(prevRecs), sortById(currRecs))) {
+    changes.recommendationCountDelta = 0; // count unchanged but content differs
+  }
+
+  // Notes (compare count and content, order-insensitive)
+  const prevNotes = from?.notes ?? [];
+  const currNotes = to.notes ?? [];
+  if (currNotes.length > prevNotes.length) {
+    changes.newNotes = currNotes.length - prevNotes.length;
+  } else if (!isDeepStrictEqual(sortById(prevNotes), sortById(currNotes))) {
+    changes.newNotes = 0; // content changed in place
+  }
+
+  // Requisitions (compare count and content, order-insensitive)
+  const prevReqs = from?.requisitions ?? [];
+  const currReqs = to.requisitions ?? [];
+  if (currReqs.length > prevReqs.length) {
+    changes.newRequisitions = currReqs.length - prevReqs.length;
+  } else if (!isDeepStrictEqual(sortById(prevReqs), sortById(currReqs))) {
+    changes.newRequisitions = 0; // status/content changed
+  }
+
+  // Report (deep comparison)
+  if (from && !isDeepStrictEqual(from.report, to.report)) {
+    changes.reportChanged = true;
+  }
+
+  return changes;
+}
+
+/** Build human-readable summary lines from diff results and meta changes.
+ *  Returns empty array if nothing changed (no file should be written). */
+export function buildChangeSummary(
+  diff: DiffResult | null,
+  meta: MetaChanges,
+  context?: { totalResults: number; roundCount: number; previousRoundCount?: number },
+): string[] {
+  const lines: string[] = [];
+
+  // First sync — no diff available
+  if (!diff && context) {
+    lines.push(`Initial sync: ${context.totalResults} results across ${context.roundCount} round(s)`);
+    return lines;
+  }
+
+  // Result changes from diffExports
+  if (diff) {
+    if (diff.summary.newCount > 0) {
+      lines.push(`${diff.summary.newCount} new result(s)`);
+    }
+    if (diff.summary.improvedCount > 0) {
+      const names = diff.improved.map(c => c.biomarkerName).join(", ");
+      lines.push(`${diff.summary.improvedCount} improved: ${names}`);
+    }
+    if (diff.summary.worsenedCount > 0) {
+      const names = diff.worsened.map(c => c.biomarkerName).join(", ");
+      lines.push(`${diff.summary.worsenedCount} worsened: ${names}`);
+    }
+    if (diff.summary.significantChangeCount > 0) {
+      lines.push(`${diff.summary.significantChangeCount} significantly changed`);
+    }
+    if (diff.summary.disappearedCount > 0) {
+      lines.push(`${diff.summary.disappearedCount} disappeared`);
+    }
+  }
+
+  // Meta changes
+  if (meta.biologicalAge) {
+    const prev = meta.biologicalAge.previous;
+    const curr = meta.biologicalAge.current;
+    lines.push(`Biological age: ${prev ?? "N/A"} → ${curr ?? "N/A"}`);
+  }
+  if (meta.bmi) {
+    const prev = meta.bmi.previous;
+    const curr = meta.bmi.current;
+    lines.push(`BMI: ${prev ?? "N/A"} → ${curr ?? "N/A"}`);
+  }
+  if (meta.recommendationCountDelta !== undefined) {
+    if (meta.recommendationCountDelta === 0) {
+      lines.push("Recommendations updated");
+    } else {
+      const sign = meta.recommendationCountDelta > 0 ? "+" : "";
+      lines.push(`Recommendations: ${sign}${meta.recommendationCountDelta}`);
+    }
+  }
+  if (meta.newNotes !== undefined) {
+    if (meta.newNotes === 0) {
+      lines.push("Notes updated");
+    } else {
+      lines.push(`${meta.newNotes} new note(s)`);
+    }
+  }
+  if (meta.newRequisitions !== undefined) {
+    if (meta.newRequisitions === 0) {
+      lines.push("Requisitions updated");
+    } else {
+      lines.push(`${meta.newRequisitions} new requisition(s)`);
+    }
+  }
+  if (meta.reportChanged) {
+    lines.push("Clinician report updated");
+  }
+
+  // Detect new rounds even when all biomarker values are stable.
+  // A new round with repeat markers may show no diff changes (all "unchanged"),
+  // but the user should still be notified that new measurements arrived.
+  if (context?.previousRoundCount !== undefined && context.roundCount > context.previousRoundCount) {
+    const newRounds = context.roundCount - context.previousRoundCount;
+    if (!lines.some(l => l.includes("new result") || l.includes("new round"))) {
+      lines.push(`${newRounds} new round(s) added`);
+    }
+  }
+
+  return lines;
+}
+
+/** Detect changes between previous aggregate and fresh API data, save notification if any.
+ *  Returns the summary lines (empty if nothing changed).
+ *  Note: "disappeared" markers are suppressed because the API's /results-report returns
+ *  only current results — comparing against the aggregate of all historical rounds would
+ *  produce false disappearances for markers not in the latest panel. Use fh_changes for
+ *  accurate round-to-round disappearance tracking. */
+export async function detectAndSaveChanges(
+  previousData: ExportData | null,
+  currentData: ExportData,
+  savedDates: string[],
+  previousRoundCount?: number,
+): Promise<string[]> {
+  const previousLabel = previousData ? deriveExportDate(previousData) : undefined;
+  const currentLabel = savedDates.length > 0 ? savedDates[savedDates.length - 1] : undefined;
+  let resultDiff = previousData ? diffExports(previousData, currentData, previousLabel, currentLabel) : null;
+
+  // Suppress disappeared markers in sync notifications.
+  // The API's /results-report returns ALL results it currently knows about, but
+  // different test rounds use different panels. The aggregate previousData includes
+  // markers from every historical round, so any marker not in the current API response
+  // (e.g. a panel-specific marker from an older round) would appear as "disappeared"
+  // even though it was never retested. For accurate round-to-round disappearance
+  // tracking, use fh_changes which compares specific rounds directly.
+  if (resultDiff && resultDiff.disappeared.length > 0) {
+    resultDiff = {
+      ...resultDiff,
+      disappeared: [],
+      summary: { ...resultDiff.summary, disappearedCount: 0 },
+    };
+  }
+
+  const metaChanges = diffMeta(previousData, currentData);
+  const context = {
+    totalResults: currentData.results.length,
+    roundCount: savedDates.length,
+    previousRoundCount,
+  };
+  const summary = buildChangeSummary(resultDiff, metaChanges, context);
+
+  if (summary.length > 0) {
+    // Strip unchanged array from persisted diff to reduce file size
+    const strippedDiff = resultDiff ? {
+      ...resultDiff,
+      unchanged: [],
+      summary: { ...resultDiff.summary, unchangedCount: 0 },
+    } : null;
+    const notification: ChangeNotification = {
+      timestamp: new Date().toISOString(),
+      syncedRounds: savedDates,
+      totalResults: currentData.results.length,
+      resultDiff: strippedDiff,
+      metaChanges,
+      summary,
+    };
+    try {
+      await saveChangeNotification(notification);
+    } catch {
+      // Non-critical — sync data is already saved, don't fail the sync
+    }
+  }
+
+  return summary;
+}
+
+function sortById<T extends { id: string }>(arr: T[]): T[] {
+  return [...arr].sort((a, b) => a.id.localeCompare(b.id));
 }
 
 function buildResultMap(data: ExportData): Map<string, ResultEntry> {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4,8 +4,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { FunctionHealthClient } from "./client.js";
 import { loadCredentials, getValidTokens } from "./auth.js";
-import { loadLatest, loadExport, loadExportResults, saveRoundExport, listExports, getSyncLog, updateRequisitionCount, loadRoundMeta, migrateToRounds } from "./store.js";
-import { diffExports } from "./diff.js";
+import { loadLatest, loadExport, loadExportResults, saveRoundExport, listExports, getSyncLog, updateRequisitionCount, loadRoundMeta, migrateToRounds, loadAllExportsAggregated, loadChangeNotifications, clearChangeNotifications } from "./store.js";
+import { diffExports, detectAndSaveChanges } from "./diff.js";
 import { fuzzyMatch, getResultName, getResultValue, buildCategoryMap, buildOutOfRangeSet, filterResults, resolveSexFilter, resolveSexDetails, findMatchingResults, validateDate, SYNC_COOLDOWN_MS } from "./utils.js";
 import { VERSION } from "./version.js";
 import type { ExportData } from "./types.js";
@@ -287,10 +287,11 @@ server.registerTool("fh_sync", {
     }
   }
 
-  const previousResultCount = syncLog.exports.reduce((sum, e) => sum + e.resultCount, 0);
-
   // Migrate old per-visit exports to round-based (idempotent)
   await migrateToRounds();
+
+  // Before saving: aggregate all existing rounds for change detection
+  const { data: previousData, roundCount: previousRoundCount } = await loadAllExportsAggregated();
 
   server.server.sendLoggingMessage({ level: "info", data: "Syncing — fetching data from Function Health API..." });
   const client = await FunctionHealthClient.create();
@@ -300,15 +301,18 @@ server.registerTool("fh_sync", {
   const savedDates = await saveRoundExport(data);
   await updateRequisitionCount(requisitionCount);
 
-  const newResults = data.results.length - previousResultCount;
+  // Change detection: compare fresh API data against previous aggregate
+  const summary = await detectAndSaveChanges(previousData, data, savedDates, previousRoundCount);
+  const newRounds = savedDates.length - previousRoundCount;
 
   return text({
     synced: true,
     roundDates: savedDates,
     resultCount: data.results.length,
-    newResults: Math.max(0, newResults),
+    newRounds,
     lastSync: new Date().toISOString(),
-    hasChanges: newResults > 0,
+    hasChanges: summary.length > 0,
+    changeSummary: summary.length > 0 ? summary : undefined,
   });
 }));
 
@@ -340,6 +344,27 @@ server.registerTool("fh_check", {
     lastSync: lastSync || "never",
     newResultsAvailable,
     note: "This checks for new test rounds only. To detect new batches within a round, run fh_sync.",
+  });
+}));
+
+// ── Notification Tools ──
+
+server.registerTool("fh_notifications", {
+  title: "Change Notifications",
+  description: "Read pending change notifications from syncs. Notifications accumulate until acknowledged. Use acknowledge=true to clear after reading.",
+  inputSchema: z.object({
+    acknowledge: z.boolean().optional().describe("Clear notifications after reading"),
+  }),
+}, safeTool(async ({ acknowledge }) => {
+  const { notifications, files } = await loadChangeNotifications();
+  let acknowledged = 0;
+  if (acknowledge && files.length > 0) {
+    acknowledged = await clearChangeNotifications(files);
+  }
+  return text({
+    count: notifications.length,
+    notifications,
+    acknowledged,
   });
 }));
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,13 +1,16 @@
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
-import type { ExportData, HealthResult, RoundMeta, SyncLog } from "./types.js";
+import type { ExportData, HealthResult, RoundMeta, SyncLog, ChangeNotification } from "./types.js";
 import { deriveExportDate, isValidDateString, writeSecure, isFileNotFound, validateDate, DIR_MODE, groupByRound, extractRequisitionId, extractVisitDates, today } from "./utils.js";
 
 const DATA_DIR = path.join(os.homedir(), ".function-health");
 const EXPORTS_DIR = path.join(DATA_DIR, "exports");
+const CHANGES_DIR = path.join(DATA_DIR, "changes");
 const LATEST_PATH = path.join(DATA_DIR, "latest.json");
 const SYNC_LOG_PATH = path.join(DATA_DIR, "sync-log.json");
+
+const MAX_CHANGE_FILES = 100;
 
 async function ensureDir(dir: string): Promise<void> {
   await fs.mkdir(dir, { recursive: true, mode: DIR_MODE });
@@ -383,6 +386,107 @@ async function rebuildSyncLog(): Promise<void> {
   log.exports = entries;
   await ensureDir(DATA_DIR);
   await writeSecure(SYNC_LOG_PATH, JSON.stringify(log, null, 2));
+}
+
+// ── Change notification persistence ──
+
+/** Save a change notification as a timestamped JSON file. Prunes oldest files beyond MAX_CHANGE_FILES. */
+export async function saveChangeNotification(n: ChangeNotification): Promise<string> {
+  await ensureDir(CHANGES_DIR);
+  const safeTs = n.timestamp.replace(/:/g, "-");
+  const filePath = path.join(CHANGES_DIR, `${safeTs}.json`);
+  await writeSecure(filePath, JSON.stringify(n, null, 2));
+
+  // Prune oldest files at write time to prevent unbounded growth
+  // while never deleting unread notifications during a read
+  try {
+    const entries = await fs.readdir(CHANGES_DIR);
+    const jsonFiles = entries.filter(e => e.endsWith(".json")).sort();
+    if (jsonFiles.length > MAX_CHANGE_FILES) {
+      const toDelete = jsonFiles.slice(0, jsonFiles.length - MAX_CHANGE_FILES);
+      await Promise.all(toDelete.map(f => fs.unlink(path.join(CHANGES_DIR, f)).catch(() => {})));
+    }
+  } catch {
+    // Non-critical — notification was already saved
+  }
+
+  return filePath;
+}
+
+/** Load all change notifications, sorted ascending by timestamp.
+ *  Returns notifications and their filenames for safe clearing. */
+export async function loadChangeNotifications(): Promise<{ notifications: ChangeNotification[]; files: string[] }> {
+  try {
+    const entries = await fs.readdir(CHANGES_DIR);
+    const jsonFiles = entries.filter(e => e.endsWith(".json")).sort();
+
+    const loaded: { notification: ChangeNotification; file: string }[] = [];
+    await Promise.all(jsonFiles.map(async (file) => {
+      try {
+        const raw = await fs.readFile(path.join(CHANGES_DIR, file), "utf-8");
+        loaded.push({ notification: JSON.parse(raw) as ChangeNotification, file });
+      } catch {
+        // Skip corrupt files
+      }
+    }));
+    loaded.sort((a, b) => a.file.localeCompare(b.file));
+    return {
+      notifications: loaded.map(l => l.notification),
+      files: loaded.map(l => l.file),
+    };
+  } catch {
+    return { notifications: [], files: [] };
+  }
+}
+
+/** Clear specific change notification files. Only deletes the named files,
+ *  avoiding race conditions with notifications created after the read. */
+export async function clearChangeNotifications(files: string[]): Promise<number> {
+  try {
+    await Promise.all(files.map(f => fs.unlink(path.join(CHANGES_DIR, f)).catch(() => {})));
+    return files.length;
+  } catch {
+    return 0;
+  }
+}
+
+/** Load all round exports and merge into a single aggregated ExportData.
+ *  Returns null if no exports exist. Also returns the round count to avoid redundant listExports() calls. */
+export async function loadAllExportsAggregated(): Promise<{ data: ExportData | null; roundCount: number }> {
+  const dates = await listExports();
+  if (dates.length === 0) return { data: null, roundCount: 0 };
+
+  const exports = await Promise.all(dates.map(d => loadExport(d)));
+  const loaded = exports.filter((e): e is ExportData => e !== null);
+  if (loaded.length === 0) return { data: null, roundCount: dates.length };
+
+  // Take shared fields from the most recent round
+  const latest = loaded[loaded.length - 1];
+
+  // Merge results (deduplicate by id)
+  const resultMap = new Map<string, ExportData["results"][0]>();
+  for (const exp of loaded) {
+    for (const r of exp.results) {
+      resultMap.set(r.id, r);
+    }
+  }
+
+  // Merge biomarkerDetails (deduplicate by name)
+  const detailMap = new Map<string, ExportData["biomarkerDetails"][0]>();
+  for (const exp of loaded) {
+    for (const d of exp.biomarkerDetails) {
+      detailMap.set(d.name.toLowerCase(), d);
+    }
+  }
+
+  return {
+    data: {
+      ...latest,
+      results: [...resultMap.values()],
+      biomarkerDetails: [...detailMap.values()],
+    },
+    roundCount: dates.length,
+  };
 }
 
 async function readJson(filePath: string, required = false): Promise<unknown> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,25 @@ export interface SyncLog {
   }>;
 }
 
+// Change notification types
+export interface MetaChanges {
+  biologicalAge?: { previous: number | null; current: number | null };
+  bmi?: { previous: number | null; current: number | null };
+  recommendationCountDelta?: number;
+  newNotes?: number;
+  newRequisitions?: number;
+  reportChanged?: boolean;
+}
+
+export interface ChangeNotification {
+  timestamp: string;
+  syncedRounds: string[];
+  totalResults: number;
+  resultDiff: DiffResult | null;
+  metaChanges: MetaChanges;
+  summary: string[];
+}
+
 // Diff types
 export interface BiomarkerChange {
   biomarkerName: string;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.4.0";
+export const VERSION = "0.5.0";

--- a/test/notifications.test.ts
+++ b/test/notifications.test.ts
@@ -1,0 +1,245 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { diffMeta, buildChangeSummary, diffExports } from "../src/diff.js";
+import { makeExport, makeResult } from "./helpers.js";
+import type { MetaChanges } from "../src/types.js";
+
+describe("diffMeta", () => {
+  it("first sync — null previous returns changes for all non-null current fields", () => {
+    const curr = makeExport({
+      biologicalAge: { biologicalAge: 42, chronologicalAge: 45 },
+      bmi: { bmi: 23.5 },
+      recommendations: [{ id: "r1" }, { id: "r2" }],
+      notes: [{ id: "n1" }],
+      requisitions: [{ id: "q1" }],
+      report: { summary: "all good" },
+    });
+    const meta = diffMeta(null, curr);
+
+    assert.deepStrictEqual(meta.biologicalAge, { previous: null, current: 42 });
+    assert.deepStrictEqual(meta.bmi, { previous: null, current: 23.5 });
+    assert.equal(meta.recommendationCountDelta, 2);
+    assert.equal(meta.newNotes, 1);
+    assert.equal(meta.newRequisitions, 1);
+    // report: no previous to compare, so reportChanged should be undefined
+    assert.equal(meta.reportChanged, undefined);
+  });
+
+  it("bio age changed, recommendations added, report same", () => {
+    const prev = makeExport({
+      biologicalAge: { biologicalAge: 44, chronologicalAge: 45 },
+      bmi: { bmi: 23.5 },
+      recommendations: [{ id: "r1" }],
+      notes: [{ id: "n1" }],
+      requisitions: [{ id: "q1" }],
+      report: { summary: "ok" },
+    });
+    const curr = makeExport({
+      biologicalAge: { biologicalAge: 42, chronologicalAge: 45 },
+      bmi: { bmi: 23.5 },
+      recommendations: [{ id: "r1" }, { id: "r2" }, { id: "r3" }],
+      notes: [{ id: "n1" }],
+      requisitions: [{ id: "q1" }],
+      report: { summary: "ok" },
+    });
+    const meta = diffMeta(prev, curr);
+
+    assert.deepStrictEqual(meta.biologicalAge, { previous: 44, current: 42 });
+    assert.equal(meta.bmi, undefined); // unchanged
+    assert.equal(meta.recommendationCountDelta, 2);
+    assert.equal(meta.newNotes, undefined); // no new notes
+    assert.equal(meta.newRequisitions, undefined); // no new reqs
+    assert.equal(meta.reportChanged, undefined); // same report
+  });
+
+  it("identical data returns empty MetaChanges", () => {
+    const data = makeExport({
+      biologicalAge: { biologicalAge: 42 },
+      bmi: { bmi: 23.5 },
+      recommendations: [{ id: "r1" }],
+      notes: [{ id: "n1" }],
+      requisitions: [{ id: "q1" }],
+      report: { summary: "ok" },
+    });
+    const meta = diffMeta(data, data);
+    assert.deepStrictEqual(meta, {});
+  });
+
+  it("detects in-place recommendation changes (same count, different content)", () => {
+    const prev = makeExport({ recommendations: [{ id: "r1", title: "Eat more fish" }] });
+    const curr = makeExport({ recommendations: [{ id: "r1", title: "Eat more vegetables" }] });
+    const meta = diffMeta(prev, curr);
+    assert.equal(meta.recommendationCountDelta, 0);
+  });
+
+  it("detects in-place note edits", () => {
+    const prev = makeExport({ notes: [{ id: "n1", content: "Original" }] });
+    const curr = makeExport({ notes: [{ id: "n1", content: "Edited" }] });
+    const meta = diffMeta(prev, curr);
+    assert.equal(meta.newNotes, 0);
+  });
+
+  it("report changed detected via deep comparison", () => {
+    const prev = makeExport({ report: { summary: "ok", details: [1, 2, 3] } });
+    const curr = makeExport({ report: { summary: "ok", details: [1, 2, 4] } });
+    const meta = diffMeta(prev, curr);
+    assert.equal(meta.reportChanged, true);
+  });
+
+  it("report with different key ordering is not flagged as changed", () => {
+    const prev = makeExport({ report: { a: 1, b: 2 } });
+    const curr = makeExport({ report: { b: 2, a: 1 } });
+    const meta = diffMeta(prev, curr);
+    assert.equal(meta.reportChanged, undefined);
+  });
+});
+
+describe("buildChangeSummary", () => {
+  it("first sync message with context", () => {
+    const meta: MetaChanges = {};
+    const lines = buildChangeSummary(null, meta, { totalResults: 113, roundCount: 1 });
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /Initial sync: 113 results across 1 round/);
+  });
+
+  it("no changes returns empty array", () => {
+    const meta: MetaChanges = {};
+    const lines = buildChangeSummary(null, meta);
+    assert.equal(lines.length, 0);
+  });
+
+  it("result diff lines", () => {
+    const prev = makeExport({
+      results: [
+        makeResult({ id: "1", biomarkerName: "Vitamin D", calculatedResult: "30", displayResult: "30", inRange: false }),
+      ],
+      biomarkers: [{ id: "b1", name: "Vitamin D", questBiomarkerCode: "", categories: [], sexDetails: [], status: null }],
+    });
+    const curr = makeExport({
+      results: [
+        makeResult({ id: "1", biomarkerName: "Vitamin D", calculatedResult: "45", displayResult: "45", inRange: true }),
+        makeResult({ id: "2", biomarkerName: "Iron", calculatedResult: "100", displayResult: "100", inRange: true }),
+      ],
+      biomarkers: [
+        { id: "b1", name: "Vitamin D", questBiomarkerCode: "", categories: [], sexDetails: [], status: null },
+        { id: "b2", name: "Iron", questBiomarkerCode: "", categories: [], sexDetails: [], status: null },
+      ],
+    });
+
+    const diff = diffExports(prev, curr);
+    const meta: MetaChanges = {};
+    const lines = buildChangeSummary(diff, meta);
+
+    assert.ok(lines.some(l => l.includes("1 new result")));
+    assert.ok(lines.some(l => l.includes("1 improved")));
+    assert.ok(lines.some(l => l.includes("Vitamin D")));
+  });
+
+  it("meta change lines", () => {
+    const meta: MetaChanges = {
+      biologicalAge: { previous: 44, current: 42 },
+      bmi: { previous: 24.0, current: 23.5 },
+      recommendationCountDelta: 3,
+      newNotes: 2,
+      newRequisitions: 1,
+      reportChanged: true,
+    };
+    const lines = buildChangeSummary(null, meta);
+
+    assert.ok(lines.some(l => l.includes("Biological age: 44 → 42")));
+    assert.ok(lines.some(l => l.includes("BMI: 24 → 23.5")));
+    assert.ok(lines.some(l => l.includes("Recommendations: +3")));
+    assert.ok(lines.some(l => l.includes("2 new note(s)")));
+    assert.ok(lines.some(l => l.includes("1 new requisition(s)")));
+    assert.ok(lines.some(l => l.includes("Clinician report updated")));
+  });
+
+  it("content-changed meta produces 'updated' lines", () => {
+    const meta: MetaChanges = {
+      recommendationCountDelta: 0,
+      newNotes: 0,
+      newRequisitions: 0,
+    };
+    const lines = buildChangeSummary(null, meta);
+    assert.ok(lines.some(l => l.includes("Recommendations updated")));
+    assert.ok(lines.some(l => l.includes("Notes updated")));
+    assert.ok(lines.some(l => l.includes("Requisitions updated")));
+  });
+
+  it("new round with stable values produces notification", () => {
+    const prev = makeExport({
+      results: [
+        makeResult({ id: "1", biomarkerName: "Vitamin D", calculatedResult: "45", displayResult: "45", inRange: true }),
+      ],
+      biomarkers: [{ id: "b1", name: "Vitamin D", questBiomarkerCode: "", categories: [], sexDetails: [], status: null }],
+    });
+    const curr = makeExport({
+      results: [
+        makeResult({ id: "2", biomarkerName: "Vitamin D", calculatedResult: "46", displayResult: "46", inRange: true }),
+      ],
+      biomarkers: [{ id: "b1", name: "Vitamin D", questBiomarkerCode: "", categories: [], sexDetails: [], status: null }],
+    });
+
+    const diff = diffExports(prev, curr);
+    const meta: MetaChanges = {};
+    // 2 rounds now, 1 previously — new round detected
+    const lines = buildChangeSummary(diff, meta, { totalResults: 1, roundCount: 2, previousRoundCount: 1 });
+
+    assert.ok(lines.some(l => l.includes("new round")));
+  });
+
+  it("does not add 'new round' line when diff already reports new biomarkers", () => {
+    const prev = makeExport({
+      results: [
+        makeResult({ id: "1", biomarkerName: "Vitamin D", calculatedResult: "45", displayResult: "45", inRange: true }),
+      ],
+      biomarkers: [{ id: "b1", name: "Vitamin D", questBiomarkerCode: "", categories: [], sexDetails: [], status: null }],
+    });
+    const curr = makeExport({
+      results: [
+        makeResult({ id: "1", biomarkerName: "Vitamin D", calculatedResult: "45", displayResult: "45", inRange: true }),
+        makeResult({ id: "2", biomarkerName: "Iron", calculatedResult: "100", displayResult: "100", inRange: true }),
+      ],
+      biomarkers: [
+        { id: "b1", name: "Vitamin D", questBiomarkerCode: "", categories: [], sexDetails: [], status: null },
+        { id: "b2", name: "Iron", questBiomarkerCode: "", categories: [], sexDetails: [], status: null },
+      ],
+    });
+
+    const diff = diffExports(prev, curr);
+    const meta: MetaChanges = {};
+    const lines = buildChangeSummary(diff, meta, { totalResults: 2, roundCount: 2, previousRoundCount: 1 });
+
+    // Should have "1 new result(s)" from the diff, but NOT "new round" since diff already covers it
+    assert.ok(lines.some(l => l.includes("1 new result")));
+    assert.ok(!lines.some(l => l.includes("new round")));
+  });
+
+  it("integration: diffExports + diffMeta + buildChangeSummary", () => {
+    const prev = makeExport({
+      results: [
+        makeResult({ id: "1", biomarkerName: "A1C", calculatedResult: "5.5", displayResult: "5.5", inRange: true }),
+      ],
+      biomarkers: [{ id: "b1", name: "A1C", questBiomarkerCode: "", categories: [], sexDetails: [], status: null }],
+      biologicalAge: { biologicalAge: 44 },
+      report: { v: 1 },
+    });
+    const curr = makeExport({
+      results: [
+        makeResult({ id: "1", biomarkerName: "A1C", calculatedResult: "5.8", displayResult: "5.8", inRange: false }),
+      ],
+      biomarkers: [{ id: "b1", name: "A1C", questBiomarkerCode: "", categories: [], sexDetails: [], status: null }],
+      biologicalAge: { biologicalAge: 42 },
+      report: { v: 2 },
+    });
+
+    const diff = diffExports(prev, curr);
+    const meta = diffMeta(prev, curr);
+    const lines = buildChangeSummary(diff, meta);
+
+    assert.ok(lines.some(l => l.includes("worsened")));
+    assert.ok(lines.some(l => l.includes("A1C")));
+    assert.ok(lines.some(l => l.includes("Biological age: 44 → 42")));
+    assert.ok(lines.some(l => l.includes("Clinician report updated")));
+  });
+});


### PR DESCRIPTION
## Summary

- Syncs now detect changes and write notification files to `~/.function-health/changes/`
- New `fh_notifications` tool reads/clears pending notifications
- Notifications persist across conversations — missed review days don't lose data
- Detects: new/improved/worsened biomarkers, biological age, BMI, recommendations, notes, requisitions, clinician report updates, new rounds with stable values
- Daily briefing workflow in skill: check notifications → present with comparisons → acknowledge
- 15 new tests (75 total), version bump to 0.5.0

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 75 tests pass
- [x] Gemini code review: APPROVE
- [x] Codex code review: remaining P2/P3 are intentional design decisions
- [ ] Manual: `fh_sync --force` with existing data → change file written
- [ ] Manual: `fh_sync --force` again with no changes → no new change file
- [ ] Manual: `fh_notifications` → returns pending changes
- [ ] Manual: `fh_notifications` with acknowledge → clears changes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)