### PR TITLE
fix: read FH credentials from .env files for MCP plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 - `refreshTokenWithFallback()` with email-match guard to prevent silent account switching
 - Env-var fallback wired into both `getValidTokens()` and client `doRefresh()` paths
-- 7 unit tests for `shouldAttemptEnvLogin()`
+- `.env` file fallback — reads `FH_EMAIL`/`FH_PASSWORD` from `~/lifeos/.env` or `~/.env` when not in `process.env` (fixes MCP plugin auth without direnv)
+- 7 unit tests for `shouldAttemptEnvLogin()`, 6 for `parseDotenv`
 - `scripts/release.sh` — automated release script (version bump, build, publish, marketplace update)
 
 ## [0.5.3] - 2026-03-13

--- a/README.md
+++ b/README.md
@@ -59,14 +59,20 @@ npx -y -p function-health-mcp function-health login
 
 #### Automatic Re-authentication
 
-Firebase tokens expire after 1 hour and are normally refreshed automatically. If the refresh token is revoked (e.g., after extended inactivity), you can set environment variables for hands-free re-authentication:
+Firebase tokens expire after 1 hour and are normally refreshed automatically. If the refresh token is revoked (e.g., after extended inactivity), you can provide credentials for hands-free re-authentication:
 
 ```bash
+# Option 1: Environment variables (e.g., in .envrc with direnv)
 export FH_EMAIL="your@email.com"
 export FH_PASSWORD="your-password"
+
+# Option 2: .env file (works without direnv — ideal for MCP plugins)
+# Add to ~/lifeos/.env or ~/.env:
+FH_EMAIL=your@email.com
+FH_PASSWORD=your-password
 ```
 
-With [direnv](https://direnv.net/), add these to your project's `.envrc` for automatic loading. When set, the MCP server will re-login automatically if token refresh fails — no manual intervention needed.
+The MCP server checks `process.env` first, then falls back to `.env` files. This means it works even when launched via `npx` (e.g., as a Claude Code plugin) where direnv isn't active.
 
 Then ask Claude about your lab results:
 

--- a/skills/fh-usage/SKILL.md
+++ b/skills/fh-usage/SKILL.md
@@ -35,7 +35,7 @@ npx -y -p function-health-mcp function-health login
 
 The `fh_login` MCP tool only checks auth status and directs users to the CLI command. Never attempt to collect credentials through the MCP tool.
 
-Credentials are stored at `~/.function-health/credentials.json` (0o600 permissions). Tokens auto-refresh via Firebase JWT. If the refresh token is revoked, the server falls back to re-login using `FH_EMAIL` and `FH_PASSWORD` environment variables (if set). Check `authHint` in `fh_status` output for guidance when auth fails.
+Credentials are stored at `~/.function-health/credentials.json` (0o600 permissions). Tokens auto-refresh via Firebase JWT. If the refresh token is revoked, the server falls back to re-login using `FH_EMAIL` and `FH_PASSWORD` (from environment variables or `~/lifeos/.env` / `~/.env` files). Check `authHint` in `fh_status` output for guidance when auth fails.
 
 ## Tool Parameter Patterns
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import type { AuthTokens, SavedCredentials } from "./types.js";
-import { BASE_URL, FIREBASE_REFRESH_URL, DEFAULT_HEADERS, delay, safeParseInt, writeSecure, isFileNotFound, DIR_MODE } from "./utils.js";
+import { BASE_URL, FIREBASE_REFRESH_URL, DEFAULT_HEADERS, delay, safeParseInt, writeSecure, isFileNotFound, DIR_MODE, getEnvVar } from "./utils.js";
 
 const CONFIG_DIR = path.join(os.homedir(), ".function-health");
 const CREDENTIALS_PATH = path.join(CONFIG_DIR, "credentials.json");
@@ -114,10 +114,11 @@ export function isTokenExpired(tokens: AuthTokens): boolean {
   return tokenAge > tokens.expiresIn - TOKEN_REFRESH_BUFFER;
 }
 
-/** Check if env-var login should be attempted. Returns credentials or null. */
+/** Check if env-var login should be attempted. Returns credentials or null.
+ *  Reads from process.env first, then falls back to .env files. */
 export function shouldAttemptEnvLogin(storedEmail: string): { email: string; password: string } | null {
-  const email = process.env.FH_EMAIL;
-  const password = process.env.FH_PASSWORD;
+  const email = getEnvVar("FH_EMAIL");
+  const password = getEnvVar("FH_PASSWORD");
   if (!email || !password) return null;
   // Guard: only fall back if env email matches the stored account (or stored email is empty/legacy)
   if (storedEmail && storedEmail.toLowerCase() !== email.toLowerCase()) return null;

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -6,7 +6,7 @@ import { FunctionHealthClient } from "./client.js";
 import { loadCredentials, getValidTokens } from "./auth.js";
 import { loadLatest, loadExport, loadExportResults, saveRoundExport, listExports, getSyncLog, updateRequisitionCount, loadRoundMeta, migrateToRounds, loadAllExportsAggregated, loadChangeNotifications, clearChangeNotifications } from "./store.js";
 import { diffExports, detectAndSaveChanges } from "./diff.js";
-import { fuzzyMatch, getResultName, getResultValue, buildCategoryMap, buildOutOfRangeSet, filterResults, resolveSexFilter, resolveSexDetails, findMatchingResults, validateDate, SYNC_COOLDOWN_MS } from "./utils.js";
+import { fuzzyMatch, getResultName, getResultValue, buildCategoryMap, buildOutOfRangeSet, filterResults, resolveSexFilter, resolveSexDetails, findMatchingResults, validateDate, SYNC_COOLDOWN_MS, getEnvVar } from "./utils.js";
 import { VERSION } from "./version.js";
 import type { ExportData } from "./types.js";
 
@@ -63,7 +63,7 @@ server.registerTool("fh_login", {
     });
   }
 
-  const hasEnvCreds = !!(process.env.FH_EMAIL && process.env.FH_PASSWORD);
+  const hasEnvCreds = !!(getEnvVar("FH_EMAIL") && getEnvVar("FH_PASSWORD"));
   return text({
     authenticated: false,
     message: "Not authenticated. Please run this command in your terminal to log in:\n\n  npx -y -p function-health-mcp function-health login\n\nThis keeps your password secure (hidden input). Once logged in, return here and run fh_sync."
@@ -91,7 +91,7 @@ server.registerTool("fh_status", {
     };
   }));
 
-  const hasEnvCreds = !!(process.env.FH_EMAIL && process.env.FH_PASSWORD);
+  const hasEnvCreds = !!(getEnvVar("FH_EMAIL") && getEnvVar("FH_PASSWORD"));
   const authHint = (auth.authenticated && !auth.tokenValid)
     ? (hasEnvCreds
       ? "Token expired. Auto-login via FH_EMAIL/FH_PASSWORD was attempted but failed. Check that your credentials are correct, or run: npx -y -p function-health-mcp function-health login"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,57 @@
 import fs from "fs/promises";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { homedir } from "os";
 import type { Biomarker, ExportData, HealthResult, SexDetails } from "./types.js";
+
+// ── Env file helpers ──
+
+/** Parse a .env file into a key-value map. Handles KEY=VALUE, quoted values, and comments. */
+export function parseDotenv(content: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    // Strip matching quotes
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    vars[key] = val;
+  }
+  return vars;
+}
+
+let dotenvCache: Record<string, string> | null = null;
+
+/** Load env vars from .env files (cached). Checks ~/lifeos/.env and ~/.env. */
+function loadDotenvFiles(): Record<string, string> {
+  if (dotenvCache) return dotenvCache;
+  dotenvCache = {};
+  const paths = [
+    resolve(homedir(), "lifeos", ".env"),
+    resolve(homedir(), ".env"),
+  ];
+  for (const p of paths) {
+    try {
+      Object.assign(dotenvCache, parseDotenv(readFileSync(p, "utf-8")));
+    } catch {
+      // File doesn't exist — skip
+    }
+  }
+  return dotenvCache;
+}
+
+/** Get an env var, falling back to .env files when not in process.env.
+ *  This handles MCP plugin processes that spawn without direnv.
+ *  Only falls back to .env files if the var is completely absent from process.env. */
+export function getEnvVar(name: string): string | undefined {
+  if (name in process.env) return process.env[name];
+  return loadDotenvFiles()[name];
+}
 
 // ── File helpers ──
 

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { shouldAttemptEnvLogin } from "../src/auth.js";
 
@@ -21,19 +21,20 @@ describe("shouldAttemptEnvLogin", () => {
   });
 
   it("returns null when env vars are not set", () => {
-    delete process.env.FH_EMAIL;
-    delete process.env.FH_PASSWORD;
+    // Use empty strings to override any .env file fallback
+    process.env.FH_EMAIL = "";
+    process.env.FH_PASSWORD = "";
     assert.equal(shouldAttemptEnvLogin("user@example.com"), null);
   });
 
   it("returns null when only FH_EMAIL is set", () => {
     process.env.FH_EMAIL = "user@example.com";
-    delete process.env.FH_PASSWORD;
+    process.env.FH_PASSWORD = "";
     assert.equal(shouldAttemptEnvLogin("user@example.com"), null);
   });
 
   it("returns null when only FH_PASSWORD is set", () => {
-    delete process.env.FH_EMAIL;
+    process.env.FH_EMAIL = "";
     process.env.FH_PASSWORD = "pass123";
     assert.equal(shouldAttemptEnvLogin("user@example.com"), null);
   });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { deriveExportDate, validateDate, isValidDateString, fuzzyMatch, getResultName, getResultValue, buildOutOfRangeSet, filterResults } from "../src/utils.js";
+import { deriveExportDate, validateDate, isValidDateString, fuzzyMatch, getResultName, getResultValue, buildOutOfRangeSet, filterResults, parseDotenv } from "../src/utils.js";
 import { exportsEqual } from "../src/store.js";
 import { makeResult, makeExport } from "./helpers.js";
 
@@ -175,5 +175,31 @@ describe("exportsEqual", () => {
 
   it("returns true for empty exports", () => {
     assert.equal(exportsEqual(makeExport(), makeExport()), true);
+  });
+});
+
+describe("parseDotenv", () => {
+  it("parses KEY=VALUE pairs", () => {
+    assert.deepEqual(parseDotenv("FOO=bar\nBAZ=qux"), { FOO: "bar", BAZ: "qux" });
+  });
+
+  it("strips double quotes", () => {
+    assert.deepEqual(parseDotenv('FOO="bar baz"'), { FOO: "bar baz" });
+  });
+
+  it("strips single quotes", () => {
+    assert.deepEqual(parseDotenv("FOO='bar baz'"), { FOO: "bar baz" });
+  });
+
+  it("skips comments and blank lines", () => {
+    assert.deepEqual(parseDotenv("# comment\n\nFOO=bar\n  # another"), { FOO: "bar" });
+  });
+
+  it("handles values with equals signs", () => {
+    assert.deepEqual(parseDotenv("URL=https://example.com?a=1&b=2"), { URL: "https://example.com?a=1&b=2" });
+  });
+
+  it("returns empty object for empty input", () => {
+    assert.deepEqual(parseDotenv(""), {});
   });
 });


### PR DESCRIPTION
## Summary

- MCP plugins spawn via `npx` without direnv, so `FH_EMAIL`/`FH_PASSWORD` env vars aren't available even when set in `.envrc`
- Added `getEnvVar()` utility that checks `process.env` first, then falls back to parsing `~/lifeos/.env` and `~/.env`
- Hand-rolled dotenv parser (no external deps), cached after first read
- All 4 call sites (`shouldAttemptEnvLogin` in auth.ts, 2x `hasEnvCreds` in mcp.ts) now use `getEnvVar()`

## Test plan

- [x] 92 tests pass (6 new for `parseDotenv`)
- [x] Build clean
- [ ] Manual: remove `FH_EMAIL`/`FH_PASSWORD` from env, add to `~/lifeos/.env`, verify MCP server picks them up

🤖 Generated with [Claude Code](https://claude.com/claude-code)